### PR TITLE
feat: expose search_all in python

### DIFF
--- a/python/sassy/example.py
+++ b/python/sassy/example.py
@@ -91,3 +91,22 @@ for i, match in enumerate(matches4):
     print(
         f"  Match {i+1}: pattern={match.pattern_idx} text={match.text_idx} start={match.text_start}, end={match.text_end}, cost={match.cost}"
     )
+
+# Example 5: Search all end positions
+print("\n=== Search All Example ===")
+pattern5 = b"ATCGATCG"
+text5 = b"GGGGATCGATCGTTTT"
+
+searcher5 = sassy.Searcher("dna", rc=False)
+matches_default = searcher5.search(pattern5, text5, k=2)
+matches_all = searcher5.search_all(pattern5, text5, k=2)
+
+print(f"Pattern: {pattern5.decode()}")
+print(f"Text:    {text5.decode()}")
+print(f"search() returned {len(matches_default)} match(es)")
+print(f"search_all() returned {len(matches_all)} match(es)")
+
+for i, match in enumerate(matches_all):
+    print(
+        f"  Match {i+1}: start={match.text_start}, end={match.text_end}, cost={match.cost}, cigar={match.cigar}"
+    )

--- a/python/sassy/example_typed.py
+++ b/python/sassy/example_typed.py
@@ -35,3 +35,6 @@ many_matches: list[Match] = searcher_ascii.search_many(
     threads=1,
     mode="single",
 )
+
+# search_all returns list[Match]
+all_matches: list[Match] = searcher_dna.search_all(b"ATCGATCG", b"GGGGATCGATCGTTTT", k=2)

--- a/python/sassy/sassy.pyi
+++ b/python/sassy/sassy.pyi
@@ -115,3 +115,21 @@ class Searcher:
             A list of Match objects.
         """
         ...
+
+    def search_all(self, pattern: bytes, text: bytes, k: int) -> list[Match]:
+        """
+        Search for a pattern in a text, returning all end positions with score <= k.
+
+        This may generate many many matches.
+        Only use this instead of `search` if you know what you are doing,
+        which typically means there is some postprocessing step to filter overlapping matches.
+
+        Args:
+            pattern: The pattern to search for.
+            text: The text to search in.
+            k: Maximum edit distance (number of allowed errors).
+
+        Returns:
+            A list of Match objects.
+        """
+        ...

--- a/src/python.rs
+++ b/src/python.rs
@@ -111,6 +111,24 @@ impl Searcher {
             }
         }
     }
+
+    #[pyo3(signature = (pattern, text, k))]
+    #[doc = "Search for a pattern in a text. Returns a list of Matches for *all* end positions with score <=k."]
+    fn search_all(
+        &mut self,
+        pattern: &Bound<'_, PyBytes>,
+        text: &Bound<'_, PyBytes>,
+        k: usize,
+    ) -> Vec<Match> {
+        // We don't let control go back to Python while we hold the slices.
+        let pattern = pattern.as_bytes();
+        let text = text.as_bytes();
+        match &mut self.searcher {
+            SearcherType::Ascii(searcher) => searcher.search_all(&pattern, &text, k),
+            SearcherType::Dna(searcher) => searcher.search_all(&pattern, &text, k),
+            SearcherType::Iupac(searcher) => searcher.search_all(&pattern, &text, k),
+        }
+    }
 }
 
 #[pymethods]


### PR DESCRIPTION
This PR exposes `search_all` in the python bindings.

We're working on a project where we need to do some custom filtering on the results that impacts which matches are most ideal. Only returning the first match for a given start position resulted in us missing some positions we would keep if we were able to filter on all the matches for a given start position.