### PR TITLE
feat: `search_all_alignments` with a lazy depth-first traversal

### DIFF
--- a/python/sassy/example_search_all_alignments.py
+++ b/python/sassy/example_search_all_alignments.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""
+Demonstrate search_all_alignments: enumerate every valid alignment at every matched
+end position, not just the single greedy best one.
+
+Use case: when you need all distinct CIGAR strings / text_start values that
+explain a match (e.g. for probabilistic scoring, read-graph construction, or
+debugging ambiguous alignments).
+
+The `margin` parameter (default 0) extends enumeration to sub-optimal alignments:
+each group yields alignments with cost <= optimal_cost + margin.  This is useful
+when the best alignment is ambiguous and near-optimal alternatives are meaningful.
+
+Run after building the bindings:
+    maturin develop --features python
+    python python/sassy/example_search_all_alignments.py
+"""
+
+import re
+import time
+from math import comb
+from sassy import AllAlignmentsAtPosIter, Match, Searcher
+
+
+def render_alignment(m: Match, text: bytes, pattern: bytes) -> str:
+    """
+    Return a three-line ASCII alignment diagram for a Match:
+
+        text row:    text bases, '-' where the pattern is inserted
+        middle row:  '|' match, '.' mismatch, ' ' gap
+        pattern row: pattern bases, '-' where the text is deleted
+
+    CIGAR ops:
+        '=' match      — both advance, '|'
+        'X' mismatch   — both advance, '.'
+        'D' deletion   — text advances, pattern gets '-'
+        'I' insertion  — pattern advances, text gets '-'
+    """
+    text_row, mid_row, pat_row = [], [], []
+    ti, pi = m.text_start, m.pattern_start
+
+    for n, op in re.findall(r"(\d+)([=XDI])", m.cigar):
+        for _ in range(int(n)):
+            if op == "=":
+                text_row.append(chr(text[ti]))
+                mid_row.append("|")
+                pat_row.append(chr(pattern[pi]))
+                ti += 1
+                pi += 1
+            elif op == "X":
+                text_row.append(chr(text[ti]))
+                mid_row.append(".")
+                pat_row.append(chr(pattern[pi]))
+                ti += 1
+                pi += 1
+            elif op == "D":  # gap in pattern
+                text_row.append(chr(text[ti]))
+                mid_row.append(" ")
+                pat_row.append("-")
+                ti += 1
+            elif op == "I":  # gap in text
+                text_row.append("-")
+                mid_row.append(" ")
+                pat_row.append(chr(pattern[pi]))
+                pi += 1
+
+    return "".join(text_row) + "\n" + "".join(mid_row) + "\n" + "".join(pat_row)
+
+
+def print_alignment(
+    m: Match, text: bytes, pattern: bytes, indent: str = "    "
+) -> None:
+    label = f"strand={m.strand}  text[{m.text_start}:{m.text_end}]  cost={m.cost}  cigar={m.cigar}"
+    print(f"{indent}{label}")
+    for line in render_alignment(m, text, pattern).splitlines():
+        print(f"{indent}  {line}")
+    print()
+
+
+# ---------------------------------------------------------------------------
+# 1. Minimal example — show that one end position can have multiple alignments
+# ---------------------------------------------------------------------------
+print("=== Multiple alignments at one end position ===\n")
+
+# Pattern "AT" vs text "ACT" at k=1:
+#   cost=1 at text_end=3, reachable via three distinct paths:
+#     Sub  : text[1:3]="CT"  — substitute C>A
+#     Del  : text[0:3]="ACT" — delete C from text
+#     Ins  : text[2:3]="T"   — insert A into text
+text1, pattern1 = b"ACT", b"AT"
+searcher = Searcher("dna", rc=False)
+groups: list[AllAlignmentsAtPosIter] = searcher.search_all_alignments(
+    pattern1, text1, k=1, margin=0
+)
+
+print(f"  pattern: {pattern1.decode()}   text: {text1.decode()}   k=1")
+print(f"  {len(groups)} end position(s) with cost <= 1\n")
+for group in groups:
+    alignments: list[Match] = list(group)
+    print(
+        f"  text_end={alignments[0].text_end}  cost={alignments[0].cost}  "
+        f"n_alignments={len(alignments)}"
+    )
+    for m in alignments:
+        print_alignment(m, text1, pattern1)
+
+# ---------------------------------------------------------------------------
+# 2. Combinatorial explosion — why early termination is essential
+# ---------------------------------------------------------------------------
+print("=== Combinatorial explosion ===\n")
+
+# The DFS branches whenever multiple ops are valid at the same matrix cell.
+# Match checks cost[i-1,j-1] == g; Ins checks cost[i,j-1] == g-1 — different
+# cells, so BOTH can be valid at once.  For a fully repetitive sequence every
+# step branches, giving C(pattern_len, k) distinct alignments.
+#
+# pattern = "A" * (t + k), text = "A" * t, k insertions required.
+# Alignments at the single end position = C(t+k, k).
+
+t, k_exp = 13, 12
+pattern_exp = b"A" * (t + k_exp)  # 25 A's
+text_exp = b"A" * t  # 13 A's
+expected = comb(t + k_exp, k_exp)  # C(25, 12) = 5,200,300
+
+print(f"  pattern: {'A' * (t + k_exp)}  (len={t + k_exp})")
+print(f"  text:    {'A' * t}  (len={t})")
+print(
+    f"  k={k_exp}  ->  C({t + k_exp},{k_exp}) = {expected:,} alignments at the one end position"
+)
+print()
+
+# Good: take only the first alignment — the DFS yields it after ~(t+k) steps.
+s_fast = Searcher("dna", rc=False)
+t0 = time.perf_counter()
+first_only = [
+    next(iter(g))
+    for g in s_fast.search_all_alignments(pattern_exp, text_exp, k_exp, margin=0)
+]
+t_fast = time.perf_counter() - t0
+print(f"  First alignment only : {len(first_only)} result(s) in {t_fast * 1e3:.2f} ms")
+
+# Bad: exhaust every alignment — forces the DFS to visit all C(25,12) leaves.
+s_slow = Searcher("dna", rc=False)
+t0 = time.perf_counter()
+total_exp = sum(
+    sum(1 for _ in g)
+    for g in s_slow.search_all_alignments(pattern_exp, text_exp, k_exp, margin=0)
+)
+t_slow = time.perf_counter() - t0
+print(f"  Exhaustive enumeration: {total_exp:,} alignments in {t_slow:.2f} s")
+print(f"  Slowdown vs first-only: {t_slow / t_fast:.0f}x")
+print()
+
+# ---------------------------------------------------------------------------
+# 3. Early termination — avoid enumerating exponentially many paths
+# ---------------------------------------------------------------------------
+print("=== Early termination (short-circuit) ===\n")
+
+# A highly repetitive sequence can produce exponentially many alignments.
+# Break out of the inner iterator as soon as you have enough.
+MAX_PER_POS = 2
+text2, pattern2 = b"AAAAAA", b"AAAA"
+searcher2 = Searcher("dna", rc=False)
+groups2 = searcher2.search_all_alignments(pattern2, text2, k=2, margin=0)
+
+print(f"  pattern: {pattern2.decode()}   text: {text2.decode()}   k=2")
+print(f"  (collecting at most {MAX_PER_POS} alignment(s) per end position)\n")
+for group in groups2:
+    collected: list[Match] = []
+    for m in group:  # lazy — only advances as far as needed
+        collected.append(m)
+        if len(collected) >= MAX_PER_POS:
+            break  # remaining paths are never computed
+    first = collected[0]
+    capped = len(collected) == MAX_PER_POS
+    print(
+        f"  text_end={first.text_end}  cost={first.cost}  "
+        f"collected={len(collected)}{'+ (capped)' if capped else ''}"
+    )
+    for m in collected:
+        print_alignment(m, text2, pattern2)
+
+# ---------------------------------------------------------------------------
+# 4. Reverse complement — strand field distinguishes Fwd / RC matches
+# ---------------------------------------------------------------------------
+print("=== Reverse complement search ===\n")
+
+# AAGT appears on the + strand; its RC (ACTT) appears on the - strand.
+text3, pattern3 = b"TTAAGTAGTACTT", b"AAGT"
+searcher3 = Searcher("dna", rc=True)
+groups3 = searcher3.search_all_alignments(pattern3, text3, k=0, margin=0)
+
+print(f"  pattern: {pattern3.decode()}   text: {text3.decode()}   k=0  rc=True\n")
+for group in groups3:
+    for m in group:
+        print_alignment(m, text3, pattern3)
+
+# ---------------------------------------------------------------------------
+# 5. Contrast with search() and search_all()
+# ---------------------------------------------------------------------------
+print("=== Comparison: search / search_all / search_all_alignments ===\n")
+
+text4, pattern4, k4 = b"GCATGGCATG", b"GCATG", 1
+s = Searcher("dna", rc=False)
+best = s.search(pattern4, text4, k4)
+all_ends = s.search_all(pattern4, text4, k4)
+# Count total alignments across all end positions.
+total = sum(
+    sum(1 for _ in g) for g in s.search_all_alignments(pattern4, text4, k4, margin=0)
+)
+
+print(f"  pattern: {pattern4.decode()}   text: {text4.decode()}   k={k4}\n")
+print(
+    f"  search()                : {len(best):2d} match(es) [one best per local-minimum end position]\n"
+    f"  search_all()            : {len(all_ends):2d} match(es) [one best alignment per end position]\n"
+    f"  search_all_alignments() : {total:2d} alignment(s) [all alignments across all end positions]\n"
+)
+
+# Show every alignment for the first end position that has more than one.
+groups4 = s.search_all_alignments(pattern4, text4, k4, margin=0)
+for group in groups4:
+    aligns = list(group)
+    if len(aligns) > 1:
+        print(f"  End position {aligns[0].text_end} has {len(aligns)} alignments:")
+        for m in aligns:
+            print_alignment(m, text4, pattern4)
+        break
+
+# ---------------------------------------------------------------------------
+# 6. margin — sub-optimal alignments within a budget above optimal
+# ---------------------------------------------------------------------------
+print("=== Sub-optimal alignments with margin ===\n")
+
+# margin=M tells the DFS to also yield alignments with cost <= optimal + M.
+# The constraint optimal + margin <= k is enforced automatically (the budget
+# is clamped to k so the search never exceeds the filled matrix window).
+#
+# Use case: when the optimal alignment is ambiguous and you want to see
+# near-optimal alternatives ranked by cost, e.g. for multi-mapping reads.
+
+text5, pattern5, k5 = b"ACGT", b"AGT", 2
+s5 = Searcher("dna", rc=False)
+
+print(f"  pattern: {pattern5.decode()}   text: {text5.decode()}   k={k5}\n")
+
+for margin in (0, 1, 2):
+    groups5 = s5.search_all_alignments(pattern5, text5, k5, margin=margin)
+    aligns5 = [m for g in groups5 for m in g]
+    by_cost: dict[int, int] = {}
+    for m in aligns5:
+        by_cost[m.cost] = by_cost.get(m.cost, 0) + 1
+    cost_summary = "  ".join(f"cost={c}: {n}" for c, n in sorted(by_cost.items()))
+    print(f"  margin={margin}  total={len(aligns5)}  [{cost_summary}]")
+
+print()
+
+# Show the alignments for margin=1 so cost breakdown is visible.
+s5b = Searcher("dna", rc=False)
+print("  Alignments with margin=1 (cost <= optimal + 1):\n")
+for group in s5b.search_all_alignments(pattern5, text5, k5, margin=1):
+    for m in group:
+        print_alignment(m, text5, pattern5)
+
+# optimal_cost() lets you inspect the minimum cost at each end position
+# before iterating, which is useful for computing the margin threshold.
+print("  optimal_cost() per end position:\n")
+s5c = Searcher("dna", rc=False)
+for group in s5c.search_all_alignments(pattern5, text5, k5, margin=0):
+    opt = group.optimal_cost()  # call before consuming the iterator
+    aligns = list(group)
+    print(f"    text_end={aligns[0].text_end}  optimal_cost={opt}")

--- a/python/sassy/sassy.pyi
+++ b/python/sassy/sassy.pyi
@@ -2,11 +2,30 @@
 
 from typing import Literal
 
-__all__ = ["features", "Match", "Searcher"]
+__all__ = ["features", "AllAlignmentsAtPosIter", "Match", "Searcher"]
 
 def features() -> None:
     """Print CPU features and throughput information."""
     ...
+
+class AllAlignmentsAtPosIter:
+    """Lazy iterator over all alignments at a single matched end position.
+
+    Do not instantiate directly; instances are obtained from
+    :meth:`Searcher.search_all_alignments`.
+
+    All yielded :class:`Match` objects share the same ``text_end``; they differ in
+    ``text_start``, ``cigar``, and (when ``margin > 0``) ``cost``.
+
+    Break out of the loop early to avoid enumerating exponentially many paths.
+    """
+
+    def __iter__(self) -> "AllAlignmentsAtPosIter": ...
+    def __next__(self) -> Match: ...
+    def optimal_cost(self) -> int:
+        """Return the minimum alignment cost at this end position."""
+        ...
+
 
 class Match:
     """A match result from a search operation."""
@@ -131,5 +150,35 @@ class Searcher:
 
         Returns:
             A list of Match objects.
+        """
+        ...
+
+    def search_all_alignments(
+        self,
+        pattern: bytes,
+        text: bytes,
+        k: int,
+        margin: int = 0,
+    ) -> list[AllAlignmentsAtPosIter]:
+        """
+        Search for all end positions with score <= k, returning a lazy iterator
+        of all alignments for each end position.
+
+        Returns a list with one :class:`AllAlignmentsAtPosIter` per matched end position.
+        Each inner iterator yields :class:`Match` objects for all distinct alignments
+        (different CIGAR strings / ``text_start`` values) consistent with that end
+        position and cost.
+
+        Iterate lazily and break early to avoid enumerating exponentially many results.
+
+        Args:
+            pattern: The pattern to search for.
+            text: The text to search in.
+            k: Maximum edit distance (number of allowed errors).
+            margin: Also yield alignments with cost <= optimal_cost + margin.
+                    Clamped to k. Default 0 (optimal alignments only).
+
+        Returns:
+            A list of AllAlignmentsAtPosIter objects (one per matched end position).
         """
         ...

--- a/src/python.rs
+++ b/src/python.rs
@@ -1,5 +1,6 @@
 use crate::profiles::{Ascii, Dna, Iupac};
 use crate::search::{self, Match, Strand};
+use crate::trace;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyString};
 
@@ -10,7 +11,37 @@ fn sassy(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(features, m)?)?;
     m.add_class::<Searcher>()?;
     m.add_class::<Match>()?;
+    m.add_class::<PyAllAlignmentsAtPosIter>()?;
     Ok(())
+}
+
+/// Lazy Python iterator over all alignments at a single matched end position.
+///
+/// Obtained from `Searcher.search_all_alignments()`. Implements the Python iterator
+/// protocol (`__iter__` / `__next__`).
+///
+/// All yielded `Match` objects share the same `text_end`; they differ in
+/// `text_start`, `cigar`, and (when `margin > 0`) `cost`.
+/// Break early to avoid enumerating exponentially many paths.
+#[pyclass(name = "AllAlignmentsAtPosIter")]
+pub struct PyAllAlignmentsAtPosIter {
+    inner: trace::AllAlignmentsAtPos,
+}
+
+#[pymethods]
+impl PyAllAlignmentsAtPosIter {
+    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    fn __next__(&mut self) -> Option<Match> {
+        self.inner.next()
+    }
+
+    #[doc = "Return the optimal (minimum) alignment cost at this end position."]
+    fn optimal_cost(&self) -> i32 {
+        self.inner.optimal_cost()
+    }
 }
 
 enum SearcherType {
@@ -110,6 +141,32 @@ impl Searcher {
                 searcher.search_many(&patterns, &texts, k, threads, mode)
             }
         }
+    }
+
+    #[pyo3(signature = (pattern, text, k, margin=0))]
+    #[doc = "Search for all end positions with score <= k, returning a lazy iterator per end position. Each iterator yields alignments with cost <= optimal_cost + margin. Break early from the lazy iterator(s) to avoid exponential enumeration."]
+    fn search_all_alignments(
+        &mut self,
+        pattern: &Bound<'_, PyBytes>,
+        text: &Bound<'_, PyBytes>,
+        k: usize,
+        margin: usize,
+    ) -> Vec<PyAllAlignmentsAtPosIter> {
+        let pattern = pattern.as_bytes();
+        let text = text.as_bytes();
+        let groups = match &mut self.searcher {
+            SearcherType::Ascii(searcher) => {
+                searcher.search_all_alignments(pattern, text, k, margin)
+            }
+            SearcherType::Dna(searcher) => searcher.search_all_alignments(pattern, text, k, margin),
+            SearcherType::Iupac(searcher) => {
+                searcher.search_all_alignments(pattern, text, k, margin)
+            }
+        };
+        groups
+            .into_iter()
+            .map(|g| PyAllAlignmentsAtPosIter { inner: g })
+            .collect()
     }
 
     #[pyo3(signature = (pattern, text, k))]

--- a/src/search.rs
+++ b/src/search.rs
@@ -5,7 +5,10 @@ use std::hint::assert_unchecked;
 use crate::delta_encoding::H;
 use crate::minima::prefix_min;
 use crate::profiles::Profile;
-use crate::trace::{CostMatrix, fill, get_trace, simd_fill, simd_fill_multipattern};
+use crate::trace::{
+    AllAlignmentsAtPos, CostMatrix, all_alignments_at_position, fill, get_trace, simd_fill,
+    simd_fill_multipattern,
+};
 use crate::{LANES, S};
 use crate::{bitpacking::compute_block_simd, delta_encoding::V};
 use pa_types::{Cigar, CigarOp, Cost, Pos};
@@ -697,6 +700,118 @@ impl<P: Profile> Searcher<P> {
             Some(filter_fn),
         );
         std::mem::take(&mut self.matches)
+    }
+
+    // ── search_all_alignments ──────────────────────────────────────────────
+
+    /// Collect end positions and build one [`AllAlignmentsAtPos`] per match.
+    ///
+    /// Only called from [`search_all_alignments_one_strand`] with a single
+    /// pattern and text.
+    fn create_alignment_groups(
+        &self,
+        pattern: &[u8],
+        text: &[u8],
+        k: Cost,
+        strand: Strand,
+        fwd_text_len: Option<usize>,
+        margin: Cost,
+    ) -> Vec<AllAlignmentsAtPos> {
+        let fill_len = pattern.len() + k as usize;
+        let mut groups = Vec::new();
+        for lane in 0..LANES {
+            for &(end_pos, _) in &self.lanes[lane].matches {
+                let offset = end_pos.saturating_sub(fill_len);
+                let slice = &text[offset..end_pos.min(text.len())];
+                groups.push(all_alignments_at_position::<P>(
+                    pattern,
+                    slice,
+                    offset,
+                    end_pos,
+                    k,
+                    self.alpha,
+                    self.max_overhang,
+                    strand,
+                    fwd_text_len,
+                    margin,
+                ));
+            }
+        }
+        groups
+    }
+
+    /// Run search for one strand and return one [`AllAlignmentsAtPos`] per match.
+    fn search_all_alignments_one_strand(
+        &mut self,
+        pattern: &[u8],
+        text: &[u8],
+        k: usize,
+        strand: Strand,
+        fwd_text_len: Option<usize>,
+        margin: Cost,
+    ) -> Vec<AllAlignmentsAtPos> {
+        self.search_positions_bounded(
+            MultiPattern::one(pattern),
+            MultiText::one(text),
+            k as Cost,
+            true,
+        );
+        self.create_alignment_groups(pattern, text, k as Cost, strand, fwd_text_len, margin)
+    }
+
+    /// Search for *all* end positions with score <= k, returning a lazy
+    /// [`AllAlignmentsAtPos`] per end position.
+    ///
+    /// Each [`AllAlignmentsAtPos`] implements [`Iterator`] and yields all
+    /// distinct alignments (different CIGARs and/or start positions) at
+    /// that position. Iteration is lazy and performs a depth-first search (DFS)
+    /// through the filled cost matrix: starting from the end cell `(i, j)`, the
+    /// DFS tries each of the four edit operations (Match>Sub>Del>Ins) in order,
+    /// recursing into valid predecessors and yielding a [`Match`] whenever the
+    /// alignment reaches a valid start cell (`j == 0` or left-overshoot).
+    /// The caller should break out of the lazy iterator(s) early to avoid exponential
+    /// enumeration.
+    ///
+    /// `margin` controls sub-optimal enumeration: the DFS within each group
+    /// yields all alignments with cost ≤ `optimal_cost + margin`. Set `margin`
+    /// to `0` to enumerate only optimal alignments.
+    pub fn search_all_alignments<I: RcSearchAble + ?Sized>(
+        &mut self,
+        pattern: &[u8],
+        input: &I,
+        k: usize,
+        margin: usize,
+    ) -> Vec<AllAlignmentsAtPos> {
+        let fwd_text = input.text();
+        let fwd_text_ref = fwd_text.as_ref();
+        let fwd_len = fwd_text_ref.len();
+        let margin = margin as Cost;
+
+        let mut groups = self.search_all_alignments_one_strand(
+            pattern,
+            fwd_text_ref,
+            k,
+            Strand::Fwd,
+            None,
+            margin,
+        );
+
+        if self.rc {
+            let rev_text = input.rev_text();
+            let rev_text_ref = rev_text.as_ref();
+            let complement_pattern = P::complement(pattern);
+            let mut rc_groups = self.search_all_alignments_one_strand(
+                &complement_pattern,
+                rev_text_ref,
+                k,
+                Strand::Rc,
+                Some(fwd_len),
+                margin,
+            );
+            groups.append(&mut rc_groups);
+        }
+
+        groups
     }
 
     /// Appends results to `self.idx_matches`.
@@ -2211,10 +2326,7 @@ mod tests {
         let mut searcher = Searcher::<Dna>::new_fwd();
         let matches = searcher.search(pattern, text, 1);
         let path = matches[0].to_path();
-        assert_eq!(
-            path,
-            vec![Pos(0, 5), Pos(1, 6), Pos(2, 7), Pos(3, 8)]
-        ); 
+        assert_eq!(path, vec![Pos(0, 5), Pos(1, 6), Pos(2, 7), Pos(3, 8)]);
         // Ends are exclusive
         assert_eq!(matches[0].pattern_end, path.last().unwrap().0 as usize + 1);
         assert_eq!(matches[0].text_end, path.last().unwrap().1 as usize + 1);
@@ -3061,5 +3173,178 @@ mod tests {
         let encoded = dna_searcher.encode_patterns(&[p]);
         let matches = dna_searcher.search_encoded_patterns(&encoded, &t, 0);
         assert_eq!(matches.len(), 0);
+    }
+
+    // ── search_all_iter_all_alignments consistency tests ────────────────────
+
+    /// Verify the basic contract of `search_all_iter_all_alignments` against `search_all`:
+    ///   - same set of (text_end, cost) end positions
+    ///   - first alignment per group matches the `search_all` greedy result exactly
+    ///   - all alignments within a group share the same text_end and cost
+    fn assert_consistent_with_search_all<P: Profile>(
+        searcher: &mut Searcher<P>,
+        pattern: &[u8],
+        text: &[u8],
+        k: usize,
+    ) {
+        let all_matches = searcher.search_all(pattern, text, k);
+        let mut groups = searcher.search_all_alignments(pattern, text, k, 0);
+
+        assert_eq!(
+            groups.len(),
+            all_matches.len(),
+            "number of end positions must match search_all"
+        );
+
+        for (group, expected) in groups.iter_mut().zip(&all_matches) {
+            let alignments: Vec<_> = group.collect();
+            assert!(
+                !alignments.is_empty(),
+                "each group must yield at least one alignment"
+            );
+
+            // Every alignment in the group must share the anchor coordinate and cost.
+            // For Fwd alignments the anchor is text_end (all start positions vary).
+            // For Rc alignments the anchor is text_start in forward coords (all
+            // end positions vary, because the RC end maps to the forward start).
+            for m in &alignments {
+                match expected.strand {
+                    Strand::Fwd => assert_eq!(
+                        m.text_end, expected.text_end,
+                        "all Fwd alignments in group must share text_end"
+                    ),
+                    Strand::Rc => assert_eq!(
+                        m.text_start, expected.text_start,
+                        "all Rc alignments in group must share text_start (forward coord)"
+                    ),
+                }
+                assert_eq!(
+                    m.cost, expected.cost,
+                    "all alignments in group must share cost"
+                );
+                assert_eq!(
+                    m.strand, expected.strand,
+                    "strand must match search_all result"
+                );
+            }
+
+            // First alignment must agree with the greedy search_all result.
+            let first = &alignments[0];
+            assert_eq!(
+                first.text_start, expected.text_start,
+                "first alignment text_start must match search_all"
+            );
+            assert_eq!(
+                first.cigar.to_string(),
+                expected.cigar.to_string(),
+                "first alignment cigar must match search_all"
+            );
+        }
+    }
+
+    #[test]
+    fn test_iter_all_alignments_consistent_with_search_all_exact() {
+        // Exact match: single end position, single alignment.
+        let mut s = Searcher::<Dna>::new_fwd();
+        assert_consistent_with_search_all(&mut s, b"ACGT", b"NNACGTNN", 0);
+    }
+
+    #[test]
+    fn test_iter_all_alignments_consistent_with_search_all_one_error() {
+        // One substitution: multiple end positions possible.
+        let mut s = Searcher::<Dna>::new_fwd();
+        assert_consistent_with_search_all(&mut s, b"GCATG", b"GCATGGCATG", 1);
+    }
+
+    #[test]
+    fn test_iter_all_alignments_consistent_with_search_all_no_matches() {
+        // No matches within k=0.
+        let mut s = Searcher::<Dna>::new_fwd();
+        assert_consistent_with_search_all(&mut s, b"ACGT", b"TTTTTTTT", 0);
+    }
+
+    #[test]
+    fn test_iter_all_alignments_consistent_with_search_all_rc() {
+        // RC match: pattern appears on minus strand.
+        let rc = Dna::reverse_complement(b"ATCGATCA");
+        let text = [b"GGGGGGGG".as_ref(), rc.as_ref(), b"GGGGGGGG"].concat();
+        let mut s = Searcher::<Dna>::new_rc();
+        assert_consistent_with_search_all(&mut s, b"ATCGATCA", &text, 0);
+    }
+
+    #[test]
+    fn test_iter_all_alignments_multiple_alignments_per_position() {
+        // "AT" vs "ACT" at k=1.
+        //
+        // Expected end positions and alignments (sorted by text_start within each group):
+        //   text_end=1, cost=1: AT : A- 1=1I
+        //   text_end=2, cost=1: AT : AC  1=1X
+        //   text_end=3, cost=1: three alignments
+        //     text_start=0: A-T : ACT 1=1D1=
+        //     text_start=1: AT  : CT  1X1=
+        //     text_start=2: AT  : -T   1I1=
+        let pattern = b"AT";
+        let text = b"ACT";
+        let mut s = Searcher::<Dna>::new_fwd();
+
+        let mut groups = s.search_all_alignments(pattern, text, 1, 0);
+
+        // Collect and sort each group by (text_start, cigar) for deterministic comparison.
+        let collected: Vec<Vec<(usize, usize, i32, String)>> = groups
+            .iter_mut()
+            .map(|g| {
+                let mut aligns: Vec<_> = g
+                    .map(|m| (m.text_start, m.text_end, m.cost, m.cigar.to_string()))
+                    .collect();
+                aligns.sort_unstable();
+                aligns
+            })
+            .collect();
+
+        assert_eq!(collected.len(), 3, "expected 3 end positions");
+
+        assert_eq!(
+            collected[0],
+            vec![(0, 1, 1, "1=1I".to_string())],
+            "text_end=1 alignments mismatch"
+        );
+        assert_eq!(
+            collected[1],
+            vec![(0, 2, 1, "1=1X".to_string())],
+            "text_end=2 alignments mismatch"
+        );
+        assert_eq!(
+            collected[2],
+            vec![
+                (0, 3, 1, "1=1D1=".to_string()),
+                (1, 3, 1, "1X1=".to_string()),
+                (2, 3, 1, "1I1=".to_string()),
+            ],
+            "text_end=3 alignments mismatch"
+        );
+    }
+
+    #[test]
+    fn test_iter_all_alignments_consistent_fuzz() {
+        // Fuzz: for random patterns/texts, verify consistency with search_all.
+        let mut searcher = Searcher::<Dna>::new_fwd();
+        let mut rc_searcher = Searcher::<Dna>::new_rc();
+
+        for _ in 0..200 {
+            let plen = random_range(3..20);
+            let tlen = random_range(plen..plen * 4);
+            let k = random_range(0..plen / 3 + 1);
+            let pattern: Vec<u8> = (0..plen).map(|_| b"ACGT"[random_range(0..4)]).collect();
+            let text: Vec<u8> = (0..tlen).map(|_| b"ACGT"[random_range(0..4)]).collect();
+
+            // Print inputs before asserting so they appear in test output on failure.
+            eprintln!(
+                "pattern={} text={} k={k}",
+                String::from_utf8_lossy(&pattern),
+                String::from_utf8_lossy(&text),
+            );
+            assert_consistent_with_search_all(&mut searcher, &pattern, &text, k);
+            assert_consistent_with_search_all(&mut rc_searcher, &pattern, &text, k);
+        }
     }
 }

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -5,6 +5,7 @@ use crate::profiles::Profile;
 use crate::search::init_deltas_for_overshoot_all_lanes;
 use crate::search::init_deltas_for_overshoot_scalar;
 use pa_types::Cigar;
+use pa_types::CigarOp;
 use pa_types::Cost;
 use pa_types::I;
 
@@ -35,11 +36,7 @@ impl CostLookup for CostMatrix {
     #[inline(always)]
     fn get(&self, i: usize, j: usize) -> Cost {
         let mut s = if let Some(alpha) = self.alpha {
-            if let Some(mo) = self.max_overhang {
-                (j.min(mo) as f32 * alpha).floor() as Cost + j.saturating_sub(mo) as Cost
-            } else {
-                (j as f32 * alpha).floor() as Cost
-            }
+            overhang_cost(j, alpha, self.max_overhang)
         } else {
             j as Cost
         };
@@ -50,6 +47,372 @@ impl CostLookup for CostMatrix {
             s += self.deltas[j + i / 64 * (self.q + 1)].value_of_prefix(i as I % 64);
         }
         s
+    }
+}
+
+/// Compute the overhang (free-end) cost for `j` unconsumed pattern characters
+/// at the text boundary, given overhang rate `alpha` and optional cap `max_overhang`.
+fn overhang_cost(j: usize, alpha: f32, max_overhang: Option<usize>) -> Cost {
+    if let Some(mo) = max_overhang {
+        (j.min(mo) as f32 * alpha).floor() as Cost + j.saturating_sub(mo) as Cost
+    } else {
+        (j as f32 * alpha).floor() as Cost
+    }
+}
+
+// ---------------------------------------------------------------------------
+// All-alignments DFS iterator
+// ---------------------------------------------------------------------------
+
+/// Which edit operation to try next during DFS backtracking.
+///
+/// Operations are tried in the order Match -> Sub -> Del -> Ins,
+/// matching the greedy preference order of `get_trace`.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum TraceOp {
+    Match,
+    Sub,
+    Del,
+    Ins,
+}
+
+impl TraceOp {
+    /// Return the next operation to try, or `None` if all have been exhausted.
+    fn next(self) -> Option<Self> {
+        match self {
+            TraceOp::Match => Some(TraceOp::Sub),
+            TraceOp::Sub => Some(TraceOp::Del),
+            TraceOp::Del => Some(TraceOp::Ins),
+            TraceOp::Ins => None,
+        }
+    }
+}
+
+/// One frame on the DFS stack.
+///
+/// Stores the coordinates `(i, j)` of the current cell, the next operation
+/// to try, and where `cigar_ops` should be truncated when we backtrack to this
+/// frame to try the next operation (erasing ops pushed by exhausted subtrees).
+///
+/// `next_op` is the *only* progress variable: because operations are always
+/// tried in the fixed order Match->Sub->Del->Ins, a single field encodes which
+/// subset has already been tried. The path taken to reach this cell is
+/// already recorded in the shared `cigar_ops` Vec, so no additional bookkeeping
+/// is needed.
+struct TraceFrame {
+    i: usize,
+    j: usize,
+    /// Remaining edit budget: starts at `max_cost` for the root frame and
+    /// decrements by 1 for each Sub/Del/Ins step. A Match step leaves it
+    /// unchanged. When the base case `j == 0` is reached, the alignment cost
+    /// is `max_cost - edit_budget`.
+    edit_budget: Cost,
+    /// Next operation to try in the DFS.
+    next_op: Option<TraceOp>,
+    /// Restore `cigar_ops` to this length when re-entering this frame.
+    ///
+    /// Each frame is entered from its parent by pushing exactly one `CigarOp`
+    /// onto the shared `cigar_ops` vec, so `cigar_len_at_entry` equals the
+    /// length of `cigar_ops` after that push. When a subtree is exhausted and
+    /// we backtrack to try the next op, truncating to `cigar_len_at_entry`
+    /// removes precisely the ops that subtree pushed — no more, no less. A
+    /// single length value suffices because the shared vec grows monotonically
+    /// within a subtree and is only shortened on backtrack.
+    cigar_len_at_entry: usize,
+}
+
+/// Lazy iterator over all valid alignments (CIGARs / start positions) for a
+/// single matched end position.
+///
+/// Implements [`Iterator<Item = Match>`] directly — use it like any standard iterator.
+///
+/// All yielded `Match` objects share the same strand. For forward alignments
+/// they also share `text_end` (start positions vary); for RC alignments they
+/// share `text_start` in forward coordinates (end positions vary, because the
+/// fixed RC end maps to the forward start).
+
+pub struct AllAlignmentsAtPos {
+    matrix: CostMatrix,
+    pattern: Vec<u8>,
+    text: Vec<u8>,
+    text_offset: usize,
+    // Stores P::is_match resolved at construction time rather than making the
+    // struct generic over P: Profile. AllAlignmentsAtPos must be non-generic
+    // because PyO3 #[pyclass] types cannot have type parameters.
+    is_match_fn: fn(u8, u8) -> bool,
+    strand: Strand,
+    /// Optimal edit cost at the end position; used for right-overshoot arithmetic.
+    optimal_cost: Cost,
+    /// Maximum total cost of any yielded `Match`: `min(optimal_cost + margin, k)`.
+    max_cost: Cost,
+    /// Exclusive end of pattern; may be < pattern.len() due to right overshoot.
+    pattern_end: usize,
+    /// `Some(fwd_len)` for RC alignments: used to flip coordinates when building a match.
+    fwd_text_len: Option<usize>,
+    stack: Vec<TraceFrame>,
+    cigar_ops: Vec<CigarOp>,
+}
+
+impl AllAlignmentsAtPos {
+    /// Return the optimal (minimum) alignment cost at this end position.
+    pub fn optimal_cost(&self) -> Cost {
+        self.optimal_cost
+    }
+
+    /// Returns `true` if `pattern[j]` and `text[i]` are considered matching
+    /// under the alphabet's scoring function.
+    fn chars_match(&self, i: usize, j: usize) -> bool {
+        (self.is_match_fn)(self.pattern[j], self.text[i])
+    }
+
+    /// Push a child frame onto the DFS stack for the given transition.
+    /// Appends `op` to the shared cigar buffer first, then records the
+    /// resulting buffer length as the frame's rollback point.
+    fn push_child_frame(&mut self, i: usize, j: usize, edit_budget: Cost, op: CigarOp) {
+        self.cigar_ops.push(op);
+        self.stack.push(TraceFrame {
+            i,
+            j,
+            edit_budget,
+            next_op: Some(TraceOp::Match),
+            cigar_len_at_entry: self.cigar_ops.len(),
+        });
+    }
+
+    /// Build a `Match` from the current `cigar_ops` state.
+    ///
+    /// `i` is the text position at the start of the alignment (within the slice).
+    /// `pattern_start` the pattern position at the start of the alignment which
+    /// is usually 0 except for left-overshoot matches.
+    /// `cost` is the alignment cost.
+    fn build_match(&self, i: usize, pattern_start: usize, cost: Cost) -> Match {
+        let mut cigar = Cigar::default();
+        // cigar_ops is in reverse order (end->start); iterate in reverse to
+        // produce forward-order output without a separate reverse pass.
+        for &op in self.cigar_ops.iter().rev() {
+            cigar.push(op);
+        }
+
+        let slice_end = self.text_offset + self.text.len();
+        let (text_start, text_end) = if let Some(fwd_len) = self.fwd_text_len {
+            // RC: flip from reversed-text coords to forward-text coords.
+            let rc_start = self.text_offset + i;
+            (fwd_len - slice_end, fwd_len - rc_start)
+        } else {
+            (self.text_offset + i, slice_end)
+        };
+
+        Match {
+            pattern_idx: 0,
+            text_idx: 0,
+            cost,
+            text_start,
+            text_end,
+            pattern_start,
+            pattern_end: self.pattern_end,
+            strand: self.strand,
+            cigar,
+        }
+    }
+}
+
+impl Iterator for AllAlignmentsAtPos {
+    type Item = Match;
+
+    /// Perform the DFS and return the next match.
+    fn next(&mut self) -> Option<Match> {
+        loop {
+            let frame = self.stack.last_mut()?;
+
+            // Restore cigar to the state when this frame was entered.
+            // This removes ops pushed by previously exhausted subtrees.
+            self.cigar_ops.truncate(frame.cigar_len_at_entry);
+
+            // ── Base case: j == 0 ────────────────────────────────────────────
+            if frame.j == 0 {
+                let i = frame.i;
+                let remaining = frame.edit_budget;
+                self.stack.pop();
+                let cost = self.max_cost - remaining;
+                return Some(self.build_match(i, 0, cost));
+            }
+
+            // ── Base case: i == 0 with left overshoot ───────────────────────
+            // When alpha is None, i == 0 is not a terminal — only Ins ops are
+            // valid (Match/Sub/Del require i > 0). Fall through to op-checking.
+            if frame.i == 0
+                && let Some(alpha) = self.matrix.alpha
+            {
+                let j = frame.j;
+                let remaining = frame.edit_budget;
+                self.stack.pop();
+                let oc = overhang_cost(j, alpha, self.matrix.max_overhang);
+                if oc <= remaining {
+                    let cost = (self.max_cost - remaining) + oc;
+                    return Some(self.build_match(0, j, cost));
+                }
+                continue;
+            }
+
+            // ── Advance to next op (or pop if exhausted) ────────────────────
+            let op = match frame.next_op {
+                None => {
+                    self.stack.pop();
+                    continue;
+                }
+                Some(op) => op,
+            };
+            // Advance before validity check so the next iteration tries the
+            // subsequent op even if this one is invalid.
+            frame.next_op = op.next();
+
+            let (i, j, edit_budget) = (frame.i, frame.j, frame.edit_budget);
+
+            // ── Check validity and push child frame ──────────────────────────
+            //
+            // Each arm checks `matrix.get(i-1, j-1)` (or the Del/Ins predecessor)
+            // against `edit_budget`: the stored value is the DP minimum cost from
+            // that predecessor to any valid start, so the check guarantees a valid
+            // completion exists within the remaining budget.
+            //
+            // With margin=0, edit_budget == matrix.get(current) on every valid
+            // path (DP monotonicity ensures this), so `<=` degenerates to `==`
+            // and the behaviour is identical to the DFS over optimal alignments.
+            match op {
+                TraceOp::Match => {
+                    if i > 0
+                        && self.matrix.get(i - 1, j - 1) <= edit_budget
+                        && self.chars_match(i - 1, j - 1)
+                    {
+                        self.push_child_frame(i - 1, j - 1, edit_budget, CigarOp::Match);
+                    }
+                }
+                TraceOp::Sub => {
+                    // Explicit !chars_match guard: in the optimal case this is
+                    // implicitly impossible (dp[i-1][j-1] >= dp[i][j] when
+                    // chars match. In allowing suboptimal matches and traversals
+                    // in the cost matrix, we must enforce a mismatch to avoid
+                    // conflating matches for substitutions.
+                    if i > 0
+                        && edit_budget >= 1
+                        && self.matrix.get(i - 1, j - 1) < edit_budget
+                        && !self.chars_match(i - 1, j - 1)
+                    {
+                        self.push_child_frame(i - 1, j - 1, edit_budget - 1, CigarOp::Sub);
+                    }
+                }
+                TraceOp::Del => {
+                    if i > 0 && edit_budget >= 1 && self.matrix.get(i - 1, j) < edit_budget {
+                        self.push_child_frame(i - 1, j, edit_budget - 1, CigarOp::Del);
+                    }
+                }
+                TraceOp::Ins => {
+                    if j > 0 && edit_budget >= 1 && self.matrix.get(i, j - 1) < edit_budget {
+                        self.push_child_frame(i, j - 1, edit_budget - 1, CigarOp::Ins);
+                    }
+                }
+            }
+            // If invalid: loop again — truncate+advance next op at top of loop.
+        }
+    }
+}
+
+/// Fill the cost matrix for `text_slice` and return an [`AllAlignmentsAtPos`]
+/// ready for depth-first traversal. Mirrors [`get_trace`].
+///
+/// `text_slice` is the window `text[text_offset .. text_offset + text_slice.len()]`.
+/// `end_pos` is the match end in the full text; it may exceed
+/// `text_offset + text_slice.len()` when the pattern overshoots the right edge.
+/// `fill_len` is the number of text columns to fill (`pattern.len() + k`).
+///
+/// `alpha` and `max_overhang` are the overhang parameters from the [`Searcher`]
+/// configuration. `strand` and `fwd_text_len` are stored in every [`Match`]
+/// yielded by the iterator; set `fwd_text_len` to `Some(fwd_len)` for RC
+/// alignments so that coordinates are flipped back to forward-text space.
+///
+/// `margin` controls sub-optimal enumeration: the iterator yields all alignments
+/// with cost <= `optimal_cost + margin`. Pass `0` to enumerate only optimal
+/// alignments. The budget is clamped to `k` so the DFS never accesses matrix
+/// cells outside the filled window.
+///
+/// Yielded [`Match`] objects always have `pattern_idx = 0` and `text_idx = 0`.
+/// This function is designed for single-pattern, single-text search only.
+#[allow(clippy::too_many_arguments)]
+pub fn all_alignments_at_position<P: Profile>(
+    pattern: &[u8],
+    text_slice: &[u8],
+    text_offset: usize,
+    end_pos: usize,
+    k: Cost,
+    alpha: Option<f32>,
+    max_overhang: Option<usize>,
+    strand: Strand,
+    fwd_text_len: Option<usize>,
+    margin: Cost,
+) -> AllAlignmentsAtPos {
+    let fill_len = pattern.len() + k as usize;
+    let mut matrix = CostMatrix::default();
+    fill::<P>(
+        pattern,
+        text_slice,
+        fill_len,
+        &mut matrix,
+        alpha,
+        max_overhang,
+    );
+
+    let mut i = end_pos - text_offset;
+    let mut j = pattern.len();
+    let mut pattern_end = pattern.len();
+    let mut total_cost = matrix.get(i, j);
+
+    // Right-overshoot adjustment — mirrors get_trace:287-299.
+    if i > text_slice.len() {
+        let overshoot = i - text_slice.len();
+        pattern_end -= overshoot;
+        let overshoot_cost = (overshoot as f32 * alpha.unwrap()).floor() as Cost;
+        total_cost += overshoot_cost;
+        i -= overshoot;
+        j -= overshoot;
+    }
+
+    // Clamp total_budget to k so the DFS never accesses cells outside the
+    // filled matrix window (fill_len = pattern.len() + k).
+    let total_budget = (total_cost + margin).min(k);
+
+    let init_frame = TraceFrame {
+        i,
+        j,
+        edit_budget: total_budget,
+        next_op: Some(TraceOp::Match),
+        cigar_len_at_entry: 0,
+    };
+
+    // NB: There are two optimizations that may be worth considering in the
+    // in the future to make the memory allocations in a sequence of returned
+    // iterators more efficient:
+    // 1. Instead of reallocating a CostMatrix at each aligned position, an
+    //    implementation could reuse a preallocated cost-matrix buffer,
+    //    initialized once by the caller.
+    // 2. Insted of holding (typically) small pattern and text byte vectors,
+    //    a pure rust implementation would hold a slice or, again, a pre-allocated
+    //    text and pattern buffer. Below, a Vec<u8> is used because the returned
+    //    struct exposed in the PyO3 interface can only hold 'static lifetimes.
+    //    Matched text and pattern slices are typically small so the
+    //    implementation below is tolerable, for now.
+    AllAlignmentsAtPos {
+        matrix,
+        pattern: pattern.to_vec(),
+        text: text_slice.to_vec(),
+        text_offset,
+        is_match_fn: P::is_match,
+        strand,
+        optimal_cost: total_cost,
+        max_cost: total_budget,
+        pattern_end,
+        fwd_text_len,
+        stack: vec![init_frame],
+        cigar_ops: Vec::new(),
     }
 }
 
@@ -316,15 +679,9 @@ pub fn get_trace<P: Profile>(
         if i == 0
             && let Some(alpha) = alpha
         {
-            let overshoot = j;
-            pattern_start = overshoot;
+            pattern_start = j;
             // Overshoot at start.
-            let overshoot_cost = if let Some(mo) = max_overhang {
-                (j.min(mo) as f32 * alpha).floor() as Cost + j.saturating_sub(mo) as Cost
-            } else {
-                (j as f32 * alpha).floor() as Cost
-            };
-            g -= overshoot_cost;
+            g -= overhang_cost(j, alpha, max_overhang);
             break;
         }
 
@@ -402,7 +759,7 @@ pub fn get_trace<P: Profile>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::profiles::Dna;
+    use crate::profiles::{Dna, Iupac};
 
     #[test]
     fn test_traceback() {
@@ -414,6 +771,283 @@ mod tests {
 
         let trace = get_trace::<Dna>(query, 0, text2.len(), text2, &cost_matrix, None, None);
         println!("Trace: {:?}", trace);
+    }
+
+    #[test]
+    fn test_all_alignments_simple() {
+        // Perfect match: exactly one alignment.
+        // "ACGT" vs "ACGT" at k=0, text_start=0, text_end=4, cost=0, cigar=4=
+        let pattern = b"ACGT".as_slice();
+        let text = b"ACGT".as_slice();
+
+        let group = all_alignments_at_position::<Dna>(
+            pattern,
+            text,
+            0,
+            text.len(),
+            0,
+            None,
+            None,
+            Strand::Fwd,
+            None,
+            0,
+        );
+        let all: Vec<_> = group.collect();
+
+        assert_eq!(all.len(), 1, "expected exactly one alignment");
+        assert_eq!(all[0].text_start, 0);
+        assert_eq!(all[0].text_end, 4);
+        assert_eq!(all[0].cost, 0);
+        assert_eq!(all[0].cigar.to_string(), "4=");
+    }
+
+    #[test]
+    fn test_all_alignments_with_errors() {
+        // "ACGT" vs "AACGT" at k=1.
+        // The minimum cost at text_end=5 is 0: text[1:5]="ACGT" is an exact match.
+        // There is exactly one alignment: text_start=1, cigar=4=, cost=0.
+        let pattern = b"ACGT".as_slice();
+        let text = b"AACGT".as_slice();
+
+        let group = all_alignments_at_position::<Dna>(
+            pattern,
+            text,
+            0,
+            text.len(),
+            1,
+            None,
+            None,
+            Strand::Fwd,
+            None,
+            0,
+        );
+        let all: Vec<_> = group.collect();
+
+        assert_eq!(all.len(), 1, "expected exactly one alignment");
+        assert_eq!(all[0].text_start, 1);
+        assert_eq!(all[0].text_end, 5);
+        assert_eq!(all[0].cost, 0);
+        assert_eq!(all[0].cigar.to_string(), "4=");
+    }
+
+    #[test]
+    fn test_all_alignments_multiple_paths() {
+        // "AT" vs "ACT" at k=1. All three cost-1 alignments land at text_end=3:
+        //  Del  : text[0:3]="ACT", cigar "1=1D1="
+        //  Sub  : text[1:3]="CT",  cigar "1X1="
+        //  Ins  : text[2:3]="T",   cigar "1I1="
+        let pattern = b"AT".as_slice();
+        let text = b"ACT".as_slice();
+
+        let group = all_alignments_at_position::<Dna>(
+            pattern,
+            text,
+            0,
+            text.len(),
+            1,
+            None,
+            None,
+            Strand::Fwd,
+            None,
+            0,
+        );
+        let mut all: Vec<_> = group.collect();
+        // Sort by text_start for deterministic comparison.
+        all.sort_by_key(|m| m.text_start);
+
+        assert_eq!(all.len(), 3, "expected exactly three alignments");
+
+        assert_eq!(all[0].text_start, 0);
+        assert_eq!(all[0].text_end, 3);
+        assert_eq!(all[0].cost, 1);
+        assert_eq!(all[0].cigar.to_string(), "1=1D1=");
+
+        assert_eq!(all[1].text_start, 1);
+        assert_eq!(all[1].text_end, 3);
+        assert_eq!(all[1].cost, 1);
+        assert_eq!(all[1].cigar.to_string(), "1X1=");
+
+        assert_eq!(all[2].text_start, 2);
+        assert_eq!(all[2].text_end, 3);
+        assert_eq!(all[2].cost, 1);
+        assert_eq!(all[2].cigar.to_string(), "1I1=");
+    }
+
+    #[test]
+    fn test_margin_zero_matches_optimal() {
+        // "AT" vs "ACT", k=1, margin=0.
+        // The three cost-1 alignments at text_end=3 in DFS order
+        // (Match subtree first, then Del, then Ins at the root level):
+        //   1X1=   : sub A>C, match T=T         (text_start=1)
+        //   1=1D1= : match A=A, del C, match T=T (text_start=0)
+        //   1I1=   : insert A, match T=T          (text_start=2)
+        let pattern = b"AT".as_slice();
+        let text = b"ACT".as_slice();
+
+        let group = all_alignments_at_position::<Dna>(
+            pattern,
+            text,
+            0,
+            text.len(),
+            1,
+            None,
+            None,
+            Strand::Fwd,
+            None,
+            0,
+        );
+        let all: Vec<_> = group.collect();
+
+        assert_eq!(all.len(), 3);
+        assert_eq!(all[0].text_start, 1);
+        assert_eq!(all[0].text_end, 3);
+        assert_eq!(all[0].cost, 1);
+        assert_eq!(all[0].cigar.to_string(), "1X1=");
+        assert_eq!(all[1].text_start, 0);
+        assert_eq!(all[1].text_end, 3);
+        assert_eq!(all[1].cost, 1);
+        assert_eq!(all[1].cigar.to_string(), "1=1D1=");
+        assert_eq!(all[2].text_start, 2);
+        assert_eq!(all[2].text_end, 3);
+        assert_eq!(all[2].cost, 1);
+        assert_eq!(all[2].cigar.to_string(), "1I1=");
+    }
+
+    #[test]
+    fn test_margin_one_yields_suboptimal() {
+        // "AT" vs "ACT", k=2, margin=1.
+        // Optimal cost is 1; budget = min(1+1, 2) = 2.
+        // DFS yields the 3 cost-1 alignments first, then 4 additional cost-2
+        // alignments reachable within the extra budget:
+        //   cost=1: 1X1= (start=1), 1=1D1= (start=0), 1I1= (start=2)
+        //   cost=2: 1I1D1= (start=1), 1=1X1D (start=0), 1X1I (start=2), 2I (start=3)
+        let pattern = b"AT".as_slice();
+        let text = b"ACT".as_slice();
+
+        let group = all_alignments_at_position::<Dna>(
+            pattern,
+            text,
+            0,
+            text.len(),
+            2,
+            None,
+            None,
+            Strand::Fwd,
+            None,
+            1,
+        );
+        let all: Vec<_> = group.collect();
+
+        // The DFS interleaves cost-1 and cost-2 results as branches open up;
+        // they are not grouped by cost. Order mirrors the Match→Sub→Del→Ins
+        // traversal and the extra branches the larger budget unlocks.
+        assert_eq!(all.len(), 7);
+        assert_eq!(all[0].text_start, 1);
+        assert_eq!(all[0].cost, 1);
+        assert_eq!(all[0].cigar.to_string(), "1X1=");
+        assert_eq!(all[1].text_start, 0);
+        assert_eq!(all[1].cost, 1);
+        assert_eq!(all[1].cigar.to_string(), "1=1D1=");
+        assert_eq!(all[2].text_start, 1);
+        assert_eq!(all[2].cost, 2);
+        assert_eq!(all[2].cigar.to_string(), "1I1D1=");
+        assert_eq!(all[3].text_start, 2);
+        assert_eq!(all[3].cost, 1);
+        assert_eq!(all[3].cigar.to_string(), "1I1=");
+        assert_eq!(all[4].text_start, 0);
+        assert_eq!(all[4].cost, 2);
+        assert_eq!(all[4].cigar.to_string(), "1=1X1D");
+        assert_eq!(all[5].text_start, 2);
+        assert_eq!(all[5].cost, 2);
+        assert_eq!(all[5].cigar.to_string(), "1X1I");
+        assert_eq!(all[6].text_start, 3);
+        assert_eq!(all[6].cost, 2);
+        assert_eq!(all[6].cigar.to_string(), "2I");
+    }
+
+    #[test]
+    fn test_margin_clamps_to_k() {
+        // k=1, margin=99: budget is clamped to k=1, so the result is exactly
+        // the same 3 alignments in the same order as margin=0.
+        let pattern = b"AT".as_slice();
+        let text = b"ACT".as_slice();
+
+        let group = all_alignments_at_position::<Dna>(
+            pattern,
+            text,
+            0,
+            text.len(),
+            1,
+            None,
+            None,
+            Strand::Fwd,
+            None,
+            99,
+        );
+        let all: Vec<_> = group.collect();
+
+        assert_eq!(all.len(), 3);
+        assert_eq!(all[0].text_start, 1);
+        assert_eq!(all[0].cost, 1);
+        assert_eq!(all[0].cigar.to_string(), "1X1=");
+        assert_eq!(all[1].text_start, 0);
+        assert_eq!(all[1].cost, 1);
+        assert_eq!(all[1].cigar.to_string(), "1=1D1=");
+        assert_eq!(all[2].text_start, 2);
+        assert_eq!(all[2].cost, 1);
+        assert_eq!(all[2].cigar.to_string(), "1I1=");
+    }
+
+    #[test]
+    fn test_all_alignments_left_overshoot() {
+        // Pattern "ACGT" aligned to text "GT" with alpha=0.0 (left overhang free, k=0).
+        // The only valid alignment matches pattern[2:4]="GT" to text[0:2]="GT", with
+        // pattern[0:2]="AC" hanging off the left at zero cost.
+        // Expected: one alignment, pattern_start=2, text_start=0, text_end=2, cost=0, cigar="2=".
+        let pattern = b"ACGT".as_slice();
+        let text = b"GT".as_slice();
+
+        let mut group = all_alignments_at_position::<Iupac>(
+            pattern,
+            text,
+            0,
+            text.len(),
+            0,
+            Some(0.0),
+            None,
+            Strand::Fwd,
+            None,
+            0,
+        );
+
+        let m = group.next().expect("expected an alignment");
+        assert_eq!(group.next(), None, "expected exactly one alignment");
+        assert_eq!(m.pattern_start, 2);
+        assert_eq!(m.pattern_end, 4);
+        assert_eq!(m.text_start, 0);
+        assert_eq!(m.text_end, 2);
+        assert_eq!(m.cost, 0);
+        assert_eq!(m.cigar.to_string(), "2=");
+    }
+
+    #[test]
+    fn test_optimal_cost_getter() {
+        let pattern = b"ACGT".as_slice();
+        let text = b"ACGT".as_slice();
+
+        let group = all_alignments_at_position::<Dna>(
+            pattern,
+            text,
+            0,
+            text.len(),
+            0,
+            None,
+            None,
+            Strand::Fwd,
+            None,
+            0,
+        );
+        assert_eq!(group.optimal_cost(), 0);
     }
 
     #[test]


### PR DESCRIPTION
# Summary

This PR implements `Searcher::search_all_alignments` that returns a lazy iterator over all alignments for all matched end positions. Motivated by use cases in which one may want to enumerate _every_ alignment up to cost k, the lazy iterator also supports the enumeration of _suboptimal_ alignments for each matching end position.

Notably, the DFS maintains a stack frame that tracks progress by recording:
1. The position in the cost matrix,
2. The next operator to try in the DFS when the DFS backtracks to a stack frame,
3. The remaining number of tolerable edits,
4. And the _length_ of the (reversed) list of cigar operations tracked by the stack frame.

Note that the _length_ of the cigar operations is satisfactory because the iterator maintains state. The CIGAR string mapping to the traversal in the DFS can simply be _truncated_ when the DFS backtracks!

A toy python program is also provided to example the intended usage of the new functionality.