### PR TITLE
Added tests and numerous small fixes to `alignment_iterator`

### DIFF
--- a/src/alignment_iterator.rs
+++ b/src/alignment_iterator.rs
@@ -8,6 +8,11 @@ use crate::{
     trace::{CostLookup, CostMatrix, fill},
 };
 
+#[cfg_attr(
+    feature = "python",
+    pyo3::pyclass(eq, from_py_object, module = "sassy")
+)]
+#[derive(PartialEq, Clone)]
 pub enum Continuation {
     /// Continue exploring the subtree.
     Continue,
@@ -32,6 +37,7 @@ impl<P: Profile> Searcher<P> {
     ///
     /// If `prune_suboptimal` is `true`, path for which some part can be replaced by exact matches are skipped.
     /// E.g., if `====` is an option, this will skip over `=I=D=`, and similarly, this will prefer `===...` over `=I=...`.
+    #[allow(clippy::too_many_arguments)]
     pub fn iterate_all_alignments(
         &self,
         pattern: &[u8],
@@ -90,8 +96,6 @@ impl<P: Profile> Searcher<P> {
             cigar: Cigar::default(),
         };
 
-        m.cost = 0;
-
         let last_row_in_diagonal = &mut vec![];
 
         // 2. iterate over the ranges
@@ -109,18 +113,21 @@ impl<P: Profile> Searcher<P> {
             last_row_in_diagonal.resize(range.len() + pattern.len() + 1, pattern.len() as _);
             last_row_in_diagonal.fill(pattern.len() as _);
 
-            for text_end in range.clone() {
+            for text_end in range.start..=range.end {
                 // This end_pos is > k.
                 if cm.get(text_end - range.start, pattern.len()) > k as Cost {
                     continue;
                 }
 
                 // 6. Backtrack to get all cost <=k alignments ending at this position.
-                // TODO: Filter out clearly suboptimal paths.
                 // TODO: Order returned paths by cost.
 
+                m.pattern_start = pattern.len();
                 m.pattern_end = pattern.len();
+                m.text_start = text_end;
                 m.text_end = text_end;
+                m.cost = 0;
+                m.cigar = Cigar::default();
 
                 let mut context = Context {
                     pattern,
@@ -174,10 +181,11 @@ impl<'s, C: Callback> Context<'s, C> {
 
         for mut op in [CigarOp::Match, CigarOp::Del, CigarOp::Ins] {
             // Filter in-range edges.
-            if !(min_pos + op.delta() <= pos) {
+            let new_pos = pos - op.delta();
+            if new_pos.0 < min_pos.0 || new_pos.1 < min_pos.1 {
+                // matrix OOB (either coordinate out of range)
                 continue;
             }
-            let new_pos = pos - op.delta();
             // Replate Match by Sub if needed
             if op == CigarOp::Match
                 && self.text[new_pos.0 as usize] != self.pattern[new_pos.1 as usize]
@@ -199,8 +207,7 @@ impl<'s, C: Callback> Context<'s, C> {
                 // We may not *leave* a diagonal if it can be extended by exact matches to the top of the matrix.
                 if op == CigarOp::Ins || op == CigarOp::Del {
                     let pat_slice = &self.pattern[..pos.1 as usize];
-                    let text_slice =
-                        &self.text[pos.0.saturating_sub(pos.1) as usize..pos.0 as usize];
+                    let text_slice = &self.text[(pos.0 - pos.1).max(0) as usize..pos.0 as usize];
                     if pat_slice == text_slice {
                         continue;
                     }
@@ -213,14 +220,16 @@ impl<'s, C: Callback> Context<'s, C> {
                     // The last (most recent) row we visited in the `new_pos` diagonal.
                     // Defaults to `pattern.len()` for bottom of the matrix.
                     let last_in_diag = self.last_row_in_diagonal[new_pos.0 as usize
-                        - new_pos.1 as usize
                         + self.pattern.len()
-                        - self.range_start];
+                        - self.range_start
+                        - new_pos.1 as usize];
                     let pat_slice = &self.pattern[new_pos.1 as usize..last_in_diag as usize];
-                    let text_slice =
-                        &self.text[new_pos.0 as usize..new_pos.0 as usize + pat_slice.len()];
-                    if pat_slice == text_slice {
-                        continue;
+                    let text_end = new_pos.0 as usize + pat_slice.len();
+                    if text_end <= self.text.len() {
+                        let text_slice = &self.text[new_pos.0 as usize..text_end];
+                        if pat_slice == text_slice {
+                            continue;
+                        }
                     }
                 }
             }
@@ -233,11 +242,11 @@ impl<'s, C: Callback> Context<'s, C> {
 
         for (op, _cost) in edges {
             let delta = op.delta();
-            let new_pos = pos + delta;
+            let new_pos = pos - delta;
 
             // update last_in_diagonal
             let diagonal =
-                new_pos.0 as usize - new_pos.1 as usize + self.pattern.len() - self.range_start;
+                new_pos.0 as usize + self.pattern.len() - self.range_start - new_pos.1 as usize;
             let old_last_in_diag = self.last_row_in_diagonal[diagonal];
             self.last_row_in_diagonal[diagonal] = new_pos.1;
 
@@ -249,10 +258,10 @@ impl<'s, C: Callback> Context<'s, C> {
             // Recurse!
             let continuation = self.dfs();
             // Revert the match
-            assert_eq!(self.m.cigar.pop_op(), Some(op));
-            self.m.cost -= op.edit_cost();
-            self.m.pattern_start += delta.1 as usize;
             self.m.text_start += delta.0 as usize;
+            self.m.pattern_start += delta.1 as usize;
+            self.m.cost -= op.edit_cost();
+            assert_eq!(self.m.cigar.pop_op(), Some(op));
 
             // Revert last_in_diagonal
             self.last_row_in_diagonal[diagonal] = old_last_in_diag;
@@ -264,6 +273,6 @@ impl<'s, C: Callback> Context<'s, C> {
             }
         }
 
-        return Continuation::Continue;
+        Continuation::Continue
     }
 }

--- a/src/alignment_iterator.rs
+++ b/src/alignment_iterator.rs
@@ -180,6 +180,10 @@ impl<'s, C: Callback> Context<'s, C> {
         let mut edges = arrayvec::ArrayVec::<(CigarOp, Cost), 3>::new();
 
         for mut op in [CigarOp::Match, CigarOp::Del, CigarOp::Ins] {
+            // Don't allow leading or trailing deletions
+            if op == CigarOp::Del && (self.m.pattern_start == 0 || self.m.pattern_start == self.pattern.len()) {
+                continue;
+            }
             // Filter in-range edges.
             let new_pos = pos - op.delta();
             if new_pos.0 < min_pos.0 || new_pos.1 < min_pos.1 {

--- a/src/alignment_iterator.rs
+++ b/src/alignment_iterator.rs
@@ -141,7 +141,7 @@ impl<P: Profile> Searcher<P> {
                     callback,
                     last_row_in_diagonal,
                 };
-                context.dfs();
+                context.dfs::<P>();
             }
         }
     }
@@ -161,7 +161,7 @@ struct Context<'s, C: Callback> {
 }
 
 impl<'s, C: Callback> Context<'s, C> {
-    fn dfs(&mut self) -> Continuation {
+    fn dfs<P: Profile>(&mut self) -> Continuation {
         let full_match = self.m.pattern_start == 0;
         if full_match || self.partial_matches {
             self.m.cigar.reverse();
@@ -187,8 +187,7 @@ impl<'s, C: Callback> Context<'s, C> {
                 continue;
             }
             // Replate Match by Sub if needed
-            if op == CigarOp::Match
-                && self.text[new_pos.0 as usize] != self.pattern[new_pos.1 as usize]
+            if op == CigarOp::Match && !P::is_match(self.text[new_pos.0 as usize], self.pattern[new_pos.1 as usize])
             {
                 op = CigarOp::Sub;
             }
@@ -208,7 +207,7 @@ impl<'s, C: Callback> Context<'s, C> {
                 if op == CigarOp::Ins || op == CigarOp::Del {
                     let pat_slice = &self.pattern[..pos.1 as usize];
                     let text_slice = &self.text[(pos.0 - pos.1).max(0) as usize..pos.0 as usize];
-                    if pat_slice == text_slice {
+                    if P::is_match_slice(pat_slice, text_slice) {
                         continue;
                     }
                 }
@@ -227,7 +226,7 @@ impl<'s, C: Callback> Context<'s, C> {
                     let text_end = new_pos.0 as usize + pat_slice.len();
                     if text_end <= self.text.len() {
                         let text_slice = &self.text[new_pos.0 as usize..text_end];
-                        if pat_slice == text_slice {
+                        if P::is_match_slice(pat_slice, text_slice) {
                             continue;
                         }
                     }
@@ -256,7 +255,7 @@ impl<'s, C: Callback> Context<'s, C> {
             self.m.cost += op.edit_cost();
             self.m.cigar.push(op);
             // Recurse!
-            let continuation = self.dfs();
+            let continuation = self.dfs::<P>();
             // Revert the match
             self.m.text_start += delta.0 as usize;
             self.m.pattern_start += delta.1 as usize;

--- a/src/pattern_tiling/search.rs
+++ b/src/pattern_tiling/search.rs
@@ -863,7 +863,7 @@ mod tests {
 
     #[test]
     // #[ignore]
-    fn fuzz_against_sassy_alll() {
+    fn fuzz_against_sassy_all() {
         // This is just sassy search all in pattern_tiling
         fuzz_against_sassy_batch(Some(0.5), true, true, false);
     }

--- a/src/profiles.rs
+++ b/src/profiles.rs
@@ -38,6 +38,13 @@ pub trait Profile: Clone + std::fmt::Debug + Sync {
     fn valid_seq(seq: &[u8]) -> bool;
     /// Return true if the two characters are a match according to profile
     fn is_match(char1: u8, char2: u8) -> bool;
+    /// Return true if every position in `pattern` matches the corresponding
+    /// position in `text` according to this profile (e.g. IUPAC ambiguity,
+    /// case-insensitivity).
+    fn is_match_slice(pattern: &[u8], text: &[u8]) -> bool {
+        pattern.len() == text.len()
+            && pattern.iter().zip(text).all(|(&p, &t)| Self::is_match(p, t))
+    }
     /// Reverse-complement the input string.
     fn reverse_complement(_query: &[u8]) -> Vec<u8> {
         unimplemented!(

--- a/src/python.rs
+++ b/src/python.rs
@@ -102,6 +102,26 @@ impl Searcher {
         }
     }
 
+    #[pyo3(signature = (pattern, text, k, prune_suboptimal=false))]
+    #[doc = "Enumerate all alignments at every Fwd end position with cost <= k.\n\
+             Returns a list of groups; each group is a list of Matches sharing the same text_end.\n\
+             RC matches are not included (full RC enumeration is not yet supported)."]
+    fn search_all_alignments(
+        &mut self,
+        pattern: &Bound<'_, PyBytes>,
+        text: &Bound<'_, PyBytes>,
+        k: usize,
+        prune_suboptimal: bool,
+    ) -> Vec<Vec<Match>> {
+        let pattern = pattern.as_bytes();
+        let text = text.as_bytes();
+        match &mut self.searcher {
+            SearcherType::Ascii(s) => s.search_all_alignments(pattern, text, k, prune_suboptimal),
+            SearcherType::Dna(s) => s.search_all_alignments(pattern, text, k, prune_suboptimal),
+            SearcherType::Iupac(s) => s.search_all_alignments(pattern, text, k, prune_suboptimal),
+        }
+    }
+
     #[pyo3(signature = (pattern, text, k))]
     #[doc = "Search for a pattern in a text. Returns a list of Matches for *all* end positions with score <=k."]
     fn search_all(

--- a/src/search.rs
+++ b/src/search.rs
@@ -3379,4 +3379,30 @@ mod tests {
         let matches = dna_searcher.search_encoded_patterns(&encoded, &t, 0);
         assert_eq!(matches.len(), 0);
     }
+
+    #[test]
+    fn check_iupac_comparison_used() {
+        let text = b"AAAAAAA";
+        let k = 2;
+
+        let count = |pattern: &[u8], prune: bool| -> usize {
+            let mut searcher = Searcher::<Iupac>::new(false, None);
+            let matches = searcher.search_all(pattern, text, k);
+            let mut n = 0;
+            searcher.iterate_all_alignments(
+                pattern, text, k, &matches, false, prune,
+                &mut |complete, _| {
+                    if complete { n += 1; }
+                    Continuation::Continue
+                },
+            );
+            n
+        };
+
+        assert_eq!(
+            count(b"NAAA", true),
+            count(b"AAAA", true),
+            "prune_suboptimal must use Profile::is_match, not raw ==, to handle N-containing patterns"
+        );
+    }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -2,6 +2,7 @@ use std::cmp::Reverse;
 use std::fmt::Debug;
 use std::hint::assert_unchecked;
 
+use crate::alignment_iterator::Continuation;
 use crate::delta_encoding::H;
 use crate::minima::prefix_min;
 use crate::profiles::Profile;
@@ -667,6 +668,49 @@ impl<P: Profile> Searcher<P> {
             None::<fn(&[u8], &[u8], Strand) -> bool>,
         );
         std::mem::take(&mut self.matches)
+    }
+
+    /// Enumerate all alignments at every forward-strand end position with cost ≤ k.
+    ///
+    /// Returns groups sorted by `text_end`; each group contains every distinct alignment
+    /// (different CIGAR or `text_start`) ending at that position.
+    /// RC matches are not included.
+    pub fn search_all_alignments(
+        &mut self,
+        pattern: &[u8],
+        text: &[u8],
+        k: usize,
+        prune_suboptimal: bool,
+    ) -> Vec<Vec<Match>> {
+        let fwd: Vec<Match> = self
+            .search_all(pattern, text, k)
+            .into_iter()
+            .filter(|m| m.strand == Strand::Fwd)
+            .collect();
+
+        let mut groups: Vec<Vec<Match>> = Vec::new();
+        let mut cur_end: Option<usize> = None;
+
+        self.iterate_all_alignments(
+            pattern,
+            text,
+            k,
+            &fwd,
+            false,
+            prune_suboptimal,
+            &mut |complete, m| {
+                if complete {
+                    if cur_end != Some(m.text_end) {
+                        groups.push(Vec::new());
+                        cur_end = Some(m.text_end);
+                    }
+                    groups.last_mut().unwrap().push(m.clone());
+                }
+                Continuation::Continue
+            },
+        );
+
+        groups
     }
 
     /// Returns matches for *all* end positions where `end_filter_fn` returns true.
@@ -1620,9 +1664,220 @@ pub(crate) fn init_deltas_for_overshoot_all_lanes(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::alignment_iterator::Continuation;
     use crate::profiles::{Dna, Iupac};
     use itertools::Itertools;
     use rand::random_range;
+
+    // --- search_all_alignments tests ---
+
+    #[test]
+    fn exact_match() {
+        let groups = Searcher::<Dna>::new(false, None).search_all_alignments(b"ACGT", b"ACGT", 0, false);
+        assert_eq!(groups.len(), 1);
+        let m = &groups[0][0];
+        assert_eq!(m.cost, 0);
+        assert_eq!(m.cigar.to_string(), "4=");
+        assert_eq!(m.pattern_start, 0);
+        assert_eq!(m.pattern_end, 4);
+        assert_eq!(m.text_start, 0);
+        assert_eq!(m.text_end, 4);
+    }
+
+    #[test]
+    fn no_match() {
+        let groups = Searcher::<Dna>::new(false, None).search_all_alignments(b"ACGT", b"TTTT", 2, false);
+        assert_eq!(groups.len(), 0);
+    }
+
+    #[test]
+    fn three_alignments_one_end() {
+        let groups = Searcher::<Dna>::new(false, None).search_all_alignments(b"AT", b"ACT", 1, false);
+        let multi: Vec<_> = groups.iter().filter(|g| g.len() > 1).collect();
+        assert_eq!(multi.len(), 1, "expected exactly one end position with >1 alignment");
+        let aligns = multi[0];
+        assert_eq!(aligns.len(), 3);
+        for m in aligns {
+            assert_eq!(m.cost, 1);
+            assert_eq!(m.pattern_start, 0);
+        }
+        let mut cigars: Vec<String> = aligns.iter().map(|m| m.cigar.to_string()).collect();
+        cigars.sort();
+        cigars.dedup();
+        assert_eq!(cigars.len(), 3);
+    }
+
+    #[test]
+    fn multiple_end_positions() {
+        let groups = Searcher::<Dna>::new(false, None).search_all_alignments(b"AA", b"AAAA", 0, false);
+        assert_eq!(groups.len(), 3, "expected three end positions, got {}", groups.len());
+        for group in &groups {
+            assert_eq!(group.len(), 1);
+            assert_eq!(group[0].cost, 0);
+            assert_eq!(group[0].pattern_start, 0);
+            assert_eq!(group[0].pattern_end, 2);
+            assert_eq!(group[0].text_end - group[0].text_start, 2);
+        }
+    }
+
+    #[test]
+    fn all_costs_within_k() {
+        let k = 2;
+        let groups = Searcher::<Dna>::new(false, None).search_all_alignments(b"ACGT", b"AACGTT", k, false);
+        for group in &groups {
+            for m in group {
+                assert!(m.cost <= k as i32, "cost {} exceeds k={}", m.cost, k);
+            }
+        }
+    }
+
+    #[test]
+    fn complete_matches_span_full_pattern() {
+        let pattern = b"ACGT";
+        let groups = Searcher::<Dna>::new(false, None).search_all_alignments(pattern, b"AACGTT", 2, false);
+        assert!(!groups.is_empty());
+        for group in &groups {
+            for m in group {
+                assert_eq!(m.pattern_start, 0);
+                assert_eq!(m.pattern_end, pattern.len());
+            }
+        }
+    }
+
+    #[test]
+    fn combinatorial_count() {
+        let t = 5usize;
+        let k = 3usize;
+        let pattern = vec![b'A'; t + k];
+        let text = vec![b'A'; t];
+        let groups = Searcher::<Dna>::new(false, None).search_all_alignments(&pattern, &text, k, false);
+        let total: usize = groups.iter().map(|g| g.len()).sum();
+        // C(8, 3) = 56
+        assert_eq!(total, 56, "expected C(8,3)=56 alignments, got {total}");
+    }
+
+    #[test]
+    fn no_partial_callbacks_when_disabled() {
+        let mut searcher = Searcher::<Dna>::new(false, None);
+        let pattern = b"ACG";
+        let text = b"AACG";
+        let k = 1;
+        let fwd: Vec<Match> = searcher
+            .search_all(pattern, text, k)
+            .into_iter()
+            .filter(|m| m.strand == Strand::Fwd)
+            .collect();
+        searcher.iterate_all_alignments(
+            pattern, text, k, &fwd, false, false,
+            &mut |complete, _m| {
+                assert!(complete, "callback fired for incomplete match with partial_matches=false");
+                Continuation::Continue
+            },
+        );
+    }
+
+    #[test]
+    fn partial_callbacks_when_enabled() {
+        let mut searcher = Searcher::<Dna>::new(false, None);
+        let pattern = b"ACG";
+        let text = b"AACG";
+        let k = 1;
+        let fwd: Vec<Match> = searcher
+            .search_all(pattern, text, k)
+            .into_iter()
+            .filter(|m| m.strand == Strand::Fwd)
+            .collect();
+        let mut saw_partial = false;
+        searcher.iterate_all_alignments(pattern, text, k, &fwd, true, false, &mut |complete, m| {
+            if !complete {
+                saw_partial = true;
+                assert!(m.pattern_start > 0, "incomplete match should have pattern_start > 0");
+            }
+            Continuation::Continue
+        });
+        assert!(saw_partial, "expected at least one partial callback with partial_matches=true");
+    }
+
+    #[test]
+    fn empty_matches_no_callbacks() {
+        let searcher = Searcher::<Dna>::new(false, None);
+        let mut called = false;
+        searcher.iterate_all_alignments(
+            b"ACGT", b"ACGT", 1, &[], false, false,
+            &mut |_complete, _m| {
+                called = true;
+                Continuation::Continue
+            },
+        );
+        assert!(!called, "callback should not fire when matches slice is empty");
+    }
+
+    #[test]
+    fn homopolymer_prune_gives_one_exact_per_end() {
+        let pattern = b"AAAA";
+        let text = b"AAAAAA";
+        let k = 2;
+        let full = Searcher::<Dna>::new(false, None).search_all_alignments(pattern, text, k, false);
+        let pruned = Searcher::<Dna>::new(false, None).search_all_alignments(pattern, text, k, true);
+        let full_total: usize = full.iter().map(|g| g.len()).sum();
+        let pruned_total: usize = pruned.iter().map(|g| g.len()).sum();
+        // Exact counts derived analytically: 6+10+31+36+51 = 134 unpruned; 3 pruned (one per end at text_end=4,5,6).
+        assert_eq!(full_total, 134, "unexpected full alignment count");
+        assert_eq!(pruned_total, 3, "unexpected pruned alignment count");
+        for group in &pruned {
+            assert_eq!(group.len(), 1, "expected exactly 1 alignment per text_end with prune=true, got {}", group.len());
+        }
+        for group in &pruned {
+            let m = &group[0];
+            assert_eq!(m.cost, 0, "expected cost 0 for pruned homopolymer alignment, got {}", m.cost);
+            assert_eq!(
+                m.text_end - m.text_start,
+                m.pattern_end - m.pattern_start,
+                "expected equal text and pattern span (exact diagonal)"
+            );
+            let expected_cigar = format!("{}=", pattern.len());
+            assert_eq!(
+                m.cigar.to_string(), expected_cigar,
+                "expected pure-match CIGAR {expected_cigar}, got {}", m.cigar.to_string()
+            );
+        }
+    }
+
+    #[test]
+    fn pruned_is_subset_of_full() {
+        use std::collections::HashSet;
+        let cases: &[(&[u8], &[u8], usize)] = &[
+            (b"AAAA", b"AAAAAA", 2),
+            (b"TTTT", b"AAAAAA", 2),
+            (b"ACGT", b"AACGTT", 2),
+            (b"AT", b"ACT", 1),
+            (b"AA", b"AAAA", 1),
+        ];
+        for &(pattern, text, k) in cases {
+            let full = Searcher::<Dna>::new(false, None).search_all_alignments(pattern, text, k, false);
+            let pruned = Searcher::<Dna>::new(false, None).search_all_alignments(pattern, text, k, true);
+            for pruned_group in &pruned {
+                let end = pruned_group[0].text_end;
+                let full_group = full
+                    .iter()
+                    .find(|g| g[0].text_end == end)
+                    .unwrap_or_else(|| panic!("pruned group at text_end={end} has no corresponding full group"));
+                let full_keys: HashSet<(usize, String)> = full_group
+                    .iter()
+                    .map(|m| (m.text_start, m.cigar.to_string()))
+                    .collect();
+                for m in pruned_group {
+                    assert!(
+                        full_keys.contains(&(m.text_start, m.cigar.to_string())),
+                        "pruned alignment not found in full set: pattern={} text={} k={k} text_end={end} cigar={}",
+                        std::str::from_utf8(pattern).unwrap(),
+                        std::str::from_utf8(text).unwrap(),
+                        m.cigar.to_string()
+                    );
+                }
+            }
+        }
+    }
 
     #[test]
     fn overhang_test() {

--- a/src/search.rs
+++ b/src/search.rs
@@ -1691,7 +1691,7 @@ mod tests {
     }
 
     #[test]
-    fn three_alignments_one_end() {
+    fn multiple_alignments_one_end() {
         let groups = Searcher::<Dna>::new(false, None).search_all_alignments(b"AT", b"ACT", 1, false);
         let multi: Vec<_> = groups.iter().filter(|g| g.len() > 1).collect();
         assert_eq!(multi.len(), 1, "expected exactly one end position with >1 alignment");
@@ -1717,17 +1717,6 @@ mod tests {
             assert_eq!(group[0].pattern_start, 0);
             assert_eq!(group[0].pattern_end, 2);
             assert_eq!(group[0].text_end - group[0].text_start, 2);
-        }
-    }
-
-    #[test]
-    fn all_costs_within_k() {
-        let k = 2;
-        let groups = Searcher::<Dna>::new(false, None).search_all_alignments(b"ACGT", b"AACGTT", k, false);
-        for group in &groups {
-            for m in group {
-                assert!(m.cost <= k as i32, "cost {} exceeds k={}", m.cost, k);
-            }
         }
     }
 
@@ -1876,6 +1865,81 @@ mod tests {
                     );
                 }
             }
+        }
+    }
+
+    // --- search_all_alignments consistency tests ---
+
+    /// For each end position returned by `search_all`, verify that `search_all_alignments`:
+    /// - produces exactly one group per end position
+    /// - yields at least one alignment per group
+    /// - all alignments in a group share the same `text_end`
+    /// - all alignments have cost ≤ k
+    /// - the first alignment matches the greedy traceback (`text_start` and CIGAR)
+    fn assert_consistent_with_search_all(searcher: &mut Searcher<Dna>, pattern: &[u8], text: &[u8], k: usize) {
+        let all_matches = searcher.search_all(pattern, text, k)
+            .into_iter()
+            .filter(|m| m.strand == Strand::Fwd)
+            .collect::<Vec<_>>();
+        let groups = searcher.search_all_alignments(pattern, text, k, false);
+
+        assert_eq!(
+            groups.len(),
+            all_matches.len(),
+            "number of groups must equal number of fwd search_all endpoints \
+             (pattern={} text={} k={k})",
+            String::from_utf8_lossy(pattern),
+            String::from_utf8_lossy(text),
+        );
+
+        for (group, expected) in groups.iter().zip(&all_matches) {
+            assert!(!group.is_empty(), "each group must yield at least one alignment");
+            for m in group {
+                assert_eq!(m.text_end, expected.text_end, "all alignments in group must share text_end");
+                assert!(m.cost <= k as i32, "alignment cost {} exceeds k={k}", m.cost);
+            }
+            let first = &group[0];
+            assert_eq!(first.text_start, expected.text_start, "first alignment text_start must match search_all");
+            assert_eq!(
+                first.cigar.to_string(), expected.cigar.to_string(),
+                "first alignment cigar must match search_all"
+            );
+        }
+    }
+
+    #[test]
+    fn search_all_alignments_consistent_exact() {
+        let mut s = Searcher::<Dna>::new(false, None);
+        assert_consistent_with_search_all(&mut s, b"ACGT", b"NNACGTNN", 0);
+    }
+
+    #[test]
+    fn search_all_alignments_consistent_one_error() {
+        let mut s = Searcher::<Dna>::new(false, None);
+        assert_consistent_with_search_all(&mut s, b"GCATG", b"GCATGGCATG", 1);
+    }
+
+    #[test]
+    fn search_all_alignments_consistent_no_matches() {
+        let mut s = Searcher::<Dna>::new(false, None);
+        assert_consistent_with_search_all(&mut s, b"ACGT", b"TTTTTTTT", 0);
+    }
+
+    #[test]
+    fn search_all_alignments_consistent_fuzz() {
+        let mut searcher = Searcher::<Dna>::new(false, None);
+        for _ in 0..200 {
+            let plen = random_range(3..20);
+            let tlen = random_range(plen..plen * 4);
+            let k = random_range(0..plen / 3 + 1);
+            let pattern: Vec<u8> = (0..plen).map(|_| b"ACGT"[random_range(0..4)]).collect();
+            let text: Vec<u8> = (0..tlen).map(|_| b"ACGT"[random_range(0..4)]).collect();
+            eprintln!(
+                "pattern={} text={} k={k}",
+                String::from_utf8_lossy(&pattern),
+                String::from_utf8_lossy(&text),
+            );
+            assert_consistent_with_search_all(&mut searcher, &pattern, &text, k);
         }
     }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -1810,8 +1810,8 @@ mod tests {
         let pruned = Searcher::<Dna>::new(false, None).search_all_alignments(pattern, text, k, true);
         let full_total: usize = full.iter().map(|g| g.len()).sum();
         let pruned_total: usize = pruned.iter().map(|g| g.len()).sum();
-        // Exact counts derived analytically: 6+10+31+36+51 = 134 unpruned; 3 pruned (one per end at text_end=4,5,6).
-        assert_eq!(full_total, 134, "unexpected full alignment count");
+        // Exact counts: 97 unpruned (leading- and trailing-deletion paths excluded); 3 pruned (one per end at text_end=4,5,6).
+        assert_eq!(full_total, 97, "unexpected full alignment count");
         assert_eq!(pruned_total, 3, "unexpected pruned alignment count");
         for group in &pruned {
             assert_eq!(group.len(), 1, "expected exactly 1 alignment per text_end with prune=true, got {}", group.len());
@@ -1829,6 +1829,35 @@ mod tests {
                 m.cigar.to_string(), expected_cigar,
                 "expected pure-match CIGAR {expected_cigar}, got {}", m.cigar.to_string()
             );
+        }
+    }
+
+    #[test]
+    fn no_leading_or_trailing_deletions() {
+        // "X" chars at each end create Del-cost-1 opportunities.  Without the filter,
+        // alignments like `1D4=` (leading) and `4=1D` (trailing) would be generated.
+        let pattern = b"ACGT";
+        let text = b"XACGTX";
+        let k = 1;
+        for &rc in &[false, true] {
+            let groups = Searcher::<Dna>::new(rc, None).search_all_alignments(pattern, text, k, false);
+            for group in &groups {
+                for m in group {
+                    let cigar = m.cigar.to_string();
+                    assert_ne!(
+                        cigar.chars().find(|c| c.is_alphabetic()),
+                        Some('D'),
+                        "unexpected leading deletion ({:?}): cigar={cigar}",
+                        m.strand,
+                    );
+                    assert_ne!(
+                        cigar.chars().last(),
+                        Some('D'),
+                        "unexpected trailing deletion ({:?}): cigar={cigar}",
+                        m.strand,
+                    );
+                }
+            }
         }
     }
 
@@ -1883,27 +1912,33 @@ mod tests {
             .collect::<Vec<_>>();
         let groups = searcher.search_all_alignments(pattern, text, k, false);
 
-        assert_eq!(
+        // Endpoints with only leading-deletion paths produce no group, so groups.len() <= all_matches.len().
+        assert!(
+            groups.len() <= all_matches.len(),
+            "number of groups ({}) must not exceed number of search_all endpoints ({}) \
+             (pattern={} text={} k={k})",
             groups.len(),
             all_matches.len(),
-            "number of groups must equal number of fwd search_all endpoints \
-             (pattern={} text={} k={k})",
             String::from_utf8_lossy(pattern),
             String::from_utf8_lossy(text),
         );
 
-        for (group, expected) in groups.iter().zip(&all_matches) {
+        for group in &groups {
             assert!(!group.is_empty(), "each group must yield at least one alignment");
+            let anchor = &group[0];
+            // Match each group to its search_all endpoint by anchor coordinate.
+            let expected = match anchor.strand {
+                Strand::Fwd => all_matches.iter().find(|m| m.strand == Strand::Fwd && m.text_end == anchor.text_end),
+                Strand::Rc  => all_matches.iter().find(|m| m.strand == Strand::Rc  && m.text_start == anchor.text_start),
+            }.unwrap_or_else(|| panic!(
+                "group anchor not found in search_all results (pattern={} text={} k={k})",
+                String::from_utf8_lossy(pattern),
+                String::from_utf8_lossy(text),
+            ));
             for m in group {
                 assert_eq!(m.text_end, expected.text_end, "all alignments in group must share text_end");
                 assert!(m.cost <= k as i32, "alignment cost {} exceeds k={k}", m.cost);
             }
-            let first = &group[0];
-            assert_eq!(first.text_start, expected.text_start, "first alignment text_start must match search_all");
-            assert_eq!(
-                first.cigar.to_string(), expected.cigar.to_string(),
-                "first alignment cigar must match search_all"
-            );
         }
     }
 

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -16,7 +16,7 @@ use std::array::from_fn;
 
 pub trait CostLookup {
     /// Get the DP cost at text position `i`, pattern position `j`.
-    /// i=0 and j=0 are are "outside" the text/pattern
+    /// i=0 and j=0 are "outside" the text/pattern
     fn get(&self, i: usize, j: usize) -> Cost;
 }
 


### PR DESCRIPTION
### Note
This is a direct rebasing/port of [TimD1/sassy PR 1](https://github.com/TimD1/sassy/pull/1) and [TimD1/sassy PR 2](https://github.com/TimD1/sassy/pull/1), which have already been reviewed.

For more details on the included bug fixes, please see those PR links.

I'm planning to follow up soon with another PR for reverse-complement alignment, and then a final PR containing the ID vs X, `--max_n_frac` filtering, and dropping `prune_suboptimal` changes.

### Summary
#### PR 1
* several bug fixes for `alignment_iterator.rs`
* added `Searcher::search_all_alignments()`
* added Python interface for `search_all_alignments()`
* added unit tests for `search_all_alignments()`
#### PR 2
* Comparisons must be made with Profile::is_match() instead of raw == to properly handle N bases
* Alignments with leading and trailing deletions are now omitted.
