### PR TITLE
Enable iterating over reverse complement alignments

### DIFF
--- a/src/alignment_iterator.rs
+++ b/src/alignment_iterator.rs
@@ -30,8 +30,10 @@ impl<F: FnMut(bool, &Match) -> Continuation> Callback for F {}
 impl<P: Profile> Searcher<P> {
     /// Iterate over _all_ alignments of cost up to `k`.
     ///
-    /// First run `search_all` to get all endpoints.
-    /// Then pass those to `all_alignments` to get an iterator over _all_ alignments.
+    /// `matches` may contain both `Strand::Fwd` and `Strand::Rc` entries.
+    /// Fwd matches are traced on the forward text; RC matches are traced on the
+    /// reversed text using the complemented pattern, then translated back to
+    /// forward-text coordinates before the callback fires.
     ///
     /// If `partial_matches` is `true`, the callback is called for *every* visited DFS state.
     ///
@@ -48,20 +50,60 @@ impl<P: Profile> Searcher<P> {
         prune_suboptimal: bool,
         callback: &mut impl Callback,
     ) {
-        let width = k + pattern.len();
+        assert_eq!(self.alpha, None, "Tracing all alignments with overhang is not yet implemented.");
 
-        // for now, assume fwd matches
-        for m in matches {
-            assert_eq!(
-                m.strand,
-                crate::Strand::Fwd,
-                "Tracing all alignments for RC matches is not yet implemented."
-            );
+        // --- Forward strand ---
+        let fwd: Vec<Match> = matches.iter().filter(|m| m.strand == Strand::Fwd).cloned().collect();
+        if !fwd.is_empty() {
+            self.iterate_one_strand(pattern, text, k, &fwd, partial_matches, prune_suboptimal, callback);
         }
-        assert_eq!(
-            self.alpha, None,
-            "Tracing all alignments with overhang is not yet implemented."
-        );
+
+        // --- Reverse-complement strand ---
+        let rc: Vec<Match> = matches.iter().filter(|m| m.strand == Strand::Rc).cloned().collect();
+        if !rc.is_empty() {
+            let fwd_len = text.len();
+            let rev_text: Vec<u8> = text.iter().rev().copied().collect();
+            let comp_pattern = P::complement(pattern);
+
+            // Translate RC matches from forward-text coords to reversed-text coords.
+            // In forward space:  text_start, text_end
+            // In reversed space: text_end_rev = fwd_len - text_start
+            //                    text_start_rev = fwd_len - text_end
+            let mut rc_rev: Vec<Match> = rc.iter().map(|m| {
+                let mut tm = m.clone();
+                tm.text_end   = fwd_len - m.text_start;
+                tm.text_start = fwd_len - m.text_end;
+                tm.strand     = Strand::Fwd; // DFS operates on reversed text as if forward
+                tm
+            }).collect();
+            rc_rev.sort_by_key(|m| m.text_end);
+
+            // Wrap callback: translate DFS results back to forward-text coords before firing.
+            let mut rc_callback = |complete: bool, m: &Match| -> Continuation {
+                let mut translated = m.clone();
+                translated.text_start = fwd_len - m.text_end;
+                translated.text_end   = fwd_len - m.text_start;
+                translated.strand     = Strand::Rc;
+                callback(complete, &translated)
+            };
+
+            self.iterate_one_strand(&comp_pattern, &rev_text, k, &rc_rev,
+                                    partial_matches, prune_suboptimal, &mut rc_callback);
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn iterate_one_strand(
+        &self,
+        pattern: &[u8],
+        text: &[u8],
+        k: usize,
+        matches: &[Match],
+        partial_matches: bool,
+        prune_suboptimal: bool,
+        callback: &mut impl Callback,
+    ) {
+        let width = k + pattern.len();
 
         // 1. Group matches as long as they are close
         let mut ranges = vec![];

--- a/src/alignment_iterator.rs
+++ b/src/alignment_iterator.rs
@@ -61,7 +61,7 @@ impl<P: Profile> Searcher<P> {
 
         // --- Forward strand ---
         if !fwd.is_empty() {
-            self.iterate_one_strand(pattern, fwd_text, k, fwd, partial_matches, prune_suboptimal, callback);
+            self.iterate_one_strand(pattern, fwd_text, k, fwd, partial_matches, prune_suboptimal, callback, None);
         }
 
         // --- Reverse-complement strand ---
@@ -71,22 +71,7 @@ impl<P: Profile> Searcher<P> {
             let rev_text = rev_text.as_ref();
             let comp_pattern = P::complement(pattern);
 
-            // Translate RC matches in-place from forward-text coords to reversed-text coords.
-            // `search_all` returns RC matches sorted by `text_start` DESCENDING in forward coords
-            // (equivalently, sorted by `text_end` ASCENDING in reversed-text coords).
-            // After the transform:
-            //   text_end_rev   = fwd_len - text_start_fwd  (ASCENDING, since text_start_fwd is DESC)
-            //   text_start_rev = fwd_len - text_end_fwd
-            // So the result is already sorted by text_end ascending — no sort or reverse needed.
-            // Strand is left unmutated — iterate_one_strand doesn't use m.strand.
-            for m in rc.iter_mut() {
-                let old_start = m.text_start;
-                m.text_start = fwd_len - m.text_end;
-                m.text_end   = fwd_len - old_start;
-            }
-            debug_assert!(rc.is_sorted_by_key(|m| m.text_end));
-
-            // Wrap callback: translate DFS results back to forward-text coords before firing.
+            // Wrap callback: translate DFS results (rev-text coords) back to fwd-text coords.
             let mut rc_callback = |complete: bool, m: &mut Match| -> Continuation {
                 let orig_start  = m.text_start;
                 let orig_end    = m.text_end;
@@ -101,16 +86,11 @@ impl<P: Profile> Searcher<P> {
                 result
             };
 
+            // RC matches are in fwd coords; pass flip=Some(fwd_len) so iterate_one_strand
+            // derives rev-text endpoints on the fly without mutating the slice.
             self.iterate_one_strand(&comp_pattern, rev_text, k, rc,
-                                    partial_matches, prune_suboptimal, &mut rc_callback);
-
-            // Restore RC slice to original forward-text coordinates.
-            // The inverse transform is the same formula applied again.
-            for m in rc.iter_mut() {
-                let old_start = m.text_start;
-                m.text_start = fwd_len - m.text_end;
-                m.text_end   = fwd_len - old_start;
-            }
+                                    partial_matches, prune_suboptimal, &mut rc_callback,
+                                    Some(fwd_len));
         }
     }
 
@@ -124,21 +104,31 @@ impl<P: Profile> Searcher<P> {
         partial_matches: bool,
         prune_suboptimal: bool,
         callback: &mut impl Callback,
+        flip: Option<usize>,
     ) {
         let width = k + pattern.len();
+
+        // When flip=Some(fwd_len), matches are in fwd coords; derive the rev-text endpoint
+        // as fwd_len - text_start (RC matches are sorted by text_start DESC in fwd coords,
+        // so fwd_len - text_start is ascending — the order iterate_one_strand requires).
+        let eff_end = |m: &Match| match flip {
+            None          => m.text_end,
+            Some(fwd_len) => fwd_len - m.text_start,
+        };
+        debug_assert!(matches.windows(2).all(|w| eff_end(&w[0]) <= eff_end(&w[1])));
 
         // 1. Group matches as long as they are close
         let mut ranges = vec![];
         if let [fm, tail @ ..] = matches {
-            let mut first_end = fm.text_end.saturating_sub(width);
-            let mut last_end = fm.text_end;
+            let mut first_end = eff_end(fm).saturating_sub(width);
+            let mut last_end = eff_end(fm);
             for m in tail {
-                if m.text_end <= last_end + width {
-                    last_end = m.text_end;
+                if eff_end(m) <= last_end + width {
+                    last_end = eff_end(m);
                 } else {
                     ranges.push(first_end..last_end);
-                    first_end = m.text_end.saturating_sub(width);
-                    last_end = m.text_end;
+                    first_end = eff_end(m).saturating_sub(width);
+                    last_end = eff_end(m);
                 }
             }
             ranges.push(first_end..last_end);

--- a/src/alignment_iterator.rs
+++ b/src/alignment_iterator.rs
@@ -3,7 +3,7 @@
 use pa_types::{Cigar, CigarOp, Cost, Pos};
 
 use crate::{
-    Match, Searcher, Strand,
+    Match, RcSearchAble, Searcher, Strand,
     profiles::Profile,
     trace::{CostLookup, CostMatrix, fill},
 };
@@ -23,9 +23,9 @@ pub enum Continuation {
 }
 
 /// (match_is_complete, (partial) match) -> continuation.
-pub trait Callback: FnMut(bool, &Match) -> Continuation {}
+pub trait Callback: FnMut(bool, &mut Match) -> Continuation {}
 
-impl<F: FnMut(bool, &Match) -> Continuation> Callback for F {}
+impl<F: FnMut(bool, &mut Match) -> Continuation> Callback for F {}
 
 impl<P: Profile> Searcher<P> {
     /// Iterate over _all_ alignments of cost up to `k`.
@@ -40,55 +40,77 @@ impl<P: Profile> Searcher<P> {
     /// If `prune_suboptimal` is `true`, path for which some part can be replaced by exact matches are skipped.
     /// E.g., if `====` is an option, this will skip over `=I=D=`, and similarly, this will prefer `===...` over `=I=...`.
     #[allow(clippy::too_many_arguments)]
-    pub fn iterate_all_alignments(
+    pub fn iterate_all_alignments<I: RcSearchAble + ?Sized>(
         &self,
         pattern: &[u8],
-        text: &[u8],
+        text: &I,
         k: usize,
-        matches: &[Match],
+        matches: &mut [Match],
         partial_matches: bool,
         prune_suboptimal: bool,
         callback: &mut impl Callback,
     ) {
         assert_eq!(self.alpha, None, "Tracing all alignments with overhang is not yet implemented.");
 
+        let fwd_text = text.text();
+        let fwd_text = fwd_text.as_ref();
+
+        // `search_all` returns Fwd matches first then Rc — find the split point.
+        let split = matches.partition_point(|m| m.strand == Strand::Fwd);
+        let (fwd, rc) = matches.split_at_mut(split);
+
         // --- Forward strand ---
-        let fwd: Vec<Match> = matches.iter().filter(|m| m.strand == Strand::Fwd).cloned().collect();
         if !fwd.is_empty() {
-            self.iterate_one_strand(pattern, text, k, &fwd, partial_matches, prune_suboptimal, callback);
+            self.iterate_one_strand(pattern, fwd_text, k, fwd, partial_matches, prune_suboptimal, callback);
         }
 
         // --- Reverse-complement strand ---
-        let rc: Vec<Match> = matches.iter().filter(|m| m.strand == Strand::Rc).cloned().collect();
         if !rc.is_empty() {
-            let fwd_len = text.len();
-            let rev_text: Vec<u8> = text.iter().rev().copied().collect();
+            let fwd_len = fwd_text.len();
+            let rev_text = text.rev_text();
+            let rev_text = rev_text.as_ref();
             let comp_pattern = P::complement(pattern);
 
-            // Translate RC matches from forward-text coords to reversed-text coords.
-            // In forward space:  text_start, text_end
-            // In reversed space: text_end_rev = fwd_len - text_start
-            //                    text_start_rev = fwd_len - text_end
-            let mut rc_rev: Vec<Match> = rc.iter().map(|m| {
-                let mut tm = m.clone();
-                tm.text_end   = fwd_len - m.text_start;
-                tm.text_start = fwd_len - m.text_end;
-                tm.strand     = Strand::Fwd; // DFS operates on reversed text as if forward
-                tm
-            }).collect();
-            rc_rev.sort_by_key(|m| m.text_end);
+            // Translate RC matches in-place from forward-text coords to reversed-text coords.
+            // `search_all` returns RC matches sorted by `text_start` DESCENDING in forward coords
+            // (equivalently, sorted by `text_end` ASCENDING in reversed-text coords).
+            // After the transform:
+            //   text_end_rev   = fwd_len - text_start_fwd  (ASCENDING, since text_start_fwd is DESC)
+            //   text_start_rev = fwd_len - text_end_fwd
+            // So the result is already sorted by text_end ascending — no sort or reverse needed.
+            // Strand is left unmutated — iterate_one_strand doesn't use m.strand.
+            for m in rc.iter_mut() {
+                let old_start = m.text_start;
+                m.text_start = fwd_len - m.text_end;
+                m.text_end   = fwd_len - old_start;
+            }
+            debug_assert!(rc.is_sorted_by_key(|m| m.text_end));
 
             // Wrap callback: translate DFS results back to forward-text coords before firing.
-            let mut rc_callback = |complete: bool, m: &Match| -> Continuation {
-                let mut translated = m.clone();
-                translated.text_start = fwd_len - m.text_end;
-                translated.text_end   = fwd_len - m.text_start;
-                translated.strand     = Strand::Rc;
-                callback(complete, &translated)
+            let mut rc_callback = |complete: bool, m: &mut Match| -> Continuation {
+                let orig_start  = m.text_start;
+                let orig_end    = m.text_end;
+                let orig_strand = m.strand;
+                m.text_start = fwd_len - orig_end;
+                m.text_end   = fwd_len - orig_start;
+                m.strand     = Strand::Rc;
+                let result = callback(complete, m);
+                m.text_start = orig_start;
+                m.text_end   = orig_end;
+                m.strand     = orig_strand;
+                result
             };
 
-            self.iterate_one_strand(&comp_pattern, &rev_text, k, &rc_rev,
+            self.iterate_one_strand(&comp_pattern, rev_text, k, rc,
                                     partial_matches, prune_suboptimal, &mut rc_callback);
+
+            // Restore RC slice to original forward-text coordinates.
+            // The inverse transform is the same formula applied again.
+            for m in rc.iter_mut() {
+                let old_start = m.text_start;
+                m.text_start = fwd_len - m.text_end;
+                m.text_end   = fwd_len - old_start;
+            }
         }
     }
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -103,9 +103,9 @@ impl Searcher {
     }
 
     #[pyo3(signature = (pattern, text, k, prune_suboptimal=false))]
-    #[doc = "Enumerate all alignments at every Fwd end position with cost <= k.\n\
-             Returns a list of groups; each group is a list of Matches sharing the same text_end.\n\
-             RC matches are not included (full RC enumeration is not yet supported)."]
+    #[doc = "Enumerate all alignments at every end position with cost <= k.\n\
+             Returns a list of groups; each group is a list of Matches sharing the same anchor coordinate.\n\
+             For Fwd matches the anchor is text_end; for RC matches the anchor is text_start."]
     fn search_all_alignments(
         &mut self,
         pattern: &Bound<'_, PyBytes>,

--- a/src/search.rs
+++ b/src/search.rs
@@ -675,50 +675,40 @@ impl<P: Profile> Searcher<P> {
     /// Returns groups sorted by `text_end`; each group contains every distinct alignment
     /// (different CIGAR or `text_start`) ending at that position.
     /// RC matches are not included.
-    pub fn search_all_alignments(
+    pub fn search_all_alignments<I: RcSearchAble + ?Sized>(
         &mut self,
         pattern: &[u8],
-        text: &[u8],
+        text: &I,
         k: usize,
         prune_suboptimal: bool,
     ) -> Vec<Vec<Match>> {
-        let all_matches = self.search_all(pattern, text, k);
+        let mut all_matches = self.search_all(pattern, text, k);
 
-        let mut groups: Vec<Vec<Match>> = Vec::new();
-        let mut cur_fwd_end:  Option<usize> = None;
-        let mut cur_rc_start: Option<usize> = None;
-
+        let mut flat: Vec<Match> = Vec::new();
         self.iterate_all_alignments(
             pattern,
             text,
             k,
-            &all_matches,
+            &mut all_matches,
             false,
             prune_suboptimal,
-            &mut |complete, m| {
+            &mut |complete, m: &mut Match| {
                 if complete {
-                    let anchor_changed = match m.strand {
-                        Strand::Fwd => {
-                            let changed = cur_fwd_end != Some(m.text_end);
-                            cur_fwd_end = Some(m.text_end);
-                            changed
-                        }
-                        Strand::Rc => {
-                            let changed = cur_rc_start != Some(m.text_start);
-                            cur_rc_start = Some(m.text_start);
-                            changed
-                        }
-                    };
-                    if anchor_changed {
-                        groups.push(Vec::new());
-                    }
-                    groups.last_mut().unwrap().push(m.clone());
+                    flat.push(m.clone());
                 }
                 Continuation::Continue
             },
         );
 
-        groups
+        let anchor_key = |m: &Match| -> (Strand, usize) {
+            match m.strand {
+                Strand::Fwd => (Strand::Fwd, m.text_end),
+                Strand::Rc  => (Strand::Rc,  m.text_start),
+            }
+        };
+        flat.chunk_by(|a, b| anchor_key(a) == anchor_key(b))
+            .map(|chunk| chunk.to_vec())
+            .collect()
     }
 
     /// Returns matches for *all* end positions where `end_filter_fn` returns true.
@@ -1759,13 +1749,13 @@ mod tests {
         let pattern = b"ACG";
         let text = b"AACG";
         let k = 1;
-        let fwd: Vec<Match> = searcher
+        let mut fwd: Vec<Match> = searcher
             .search_all(pattern, text, k)
             .into_iter()
             .filter(|m| m.strand == Strand::Fwd)
             .collect();
         searcher.iterate_all_alignments(
-            pattern, text, k, &fwd, false, false,
+            pattern, text, k, &mut fwd, false, false,
             &mut |complete, _m| {
                 assert!(complete, "callback fired for incomplete match with partial_matches=false");
                 Continuation::Continue
@@ -1779,13 +1769,13 @@ mod tests {
         let pattern = b"ACG";
         let text = b"AACG";
         let k = 1;
-        let fwd: Vec<Match> = searcher
+        let mut fwd: Vec<Match> = searcher
             .search_all(pattern, text, k)
             .into_iter()
             .filter(|m| m.strand == Strand::Fwd)
             .collect();
         let mut saw_partial = false;
-        searcher.iterate_all_alignments(pattern, text, k, &fwd, true, false, &mut |complete, m| {
+        searcher.iterate_all_alignments(pattern, text, k, &mut fwd, true, false, &mut |complete, m| {
             if !complete {
                 saw_partial = true;
                 assert!(m.pattern_start > 0, "incomplete match should have pattern_start > 0");
@@ -1800,7 +1790,7 @@ mod tests {
         let searcher = Searcher::<Dna>::new(false, None);
         let mut called = false;
         searcher.iterate_all_alignments(
-            b"ACGT", b"ACGT", 1, &[], false, false,
+            b"ACGT", b"ACGT", 1, &mut [], false, false,
             &mut |_complete, _m| {
                 called = true;
                 Continuation::Continue
@@ -1975,6 +1965,48 @@ mod tests {
         let text = [b"GGGGGGGG".as_ref(), rc.as_ref(), b"GGGGGGGG"].concat();
         let mut s = Searcher::<Dna>::new(true, None);
         assert_consistent_with_search_all(&mut s, b"ATCGATCA", &text, 0);
+    }
+
+    #[test]
+    fn search_all_alignments_rc_fuzz() {
+        use rand::rngs::StdRng;
+        use rand::{RngExt, SeedableRng};
+        let mut rng = StdRng::seed_from_u64(42);
+        let bases = b"ACGT";
+
+        for _ in 0..1000 {
+            let plen = rng.random_range(4..=20);
+            let tlen = rng.random_range(plen..=plen + 10);
+            let k    = rng.random_range(0..=3usize);
+
+            let pattern: Vec<u8> = (0..plen).map(|_| bases[rng.random_range(0..4usize)]).collect();
+            let text:    Vec<u8> = (0..tlen).map(|_| bases[rng.random_range(0..4usize)]).collect();
+
+            let mut searcher = Searcher::<Dna>::new(true, None);
+            let groups = searcher.search_all_alignments(&pattern, &text, k, false);
+
+            for group in &groups {
+                for m in group {
+                    assert!(
+                        m.cost as usize <= k,
+                        "cost {} > k={} for pattern={} text={}",
+                        m.cost, k,
+                        String::from_utf8_lossy(&pattern),
+                        String::from_utf8_lossy(&text),
+                    );
+                    if m.strand == Strand::Rc {
+                        assert!(
+                            m.text_start <= m.text_end,
+                            "RC match has text_start > text_end: {:?}", m
+                        );
+                        assert!(
+                            m.text_end <= text.len(),
+                            "RC match text_end out of bounds: {:?}", m
+                        );
+                    }
+                }
+            }
+        }
     }
 
     #[test]
@@ -3441,10 +3473,10 @@ mod tests {
 
         let count = |pattern: &[u8], prune: bool| -> usize {
             let mut searcher = Searcher::<Iupac>::new(false, None);
-            let matches = searcher.search_all(pattern, text, k);
+            let mut matches = searcher.search_all(pattern, text, k);
             let mut n = 0;
             searcher.iterate_all_alignments(
-                pattern, text, k, &matches, false, prune,
+                pattern, text, k, &mut matches, false, prune,
                 &mut |complete, _| {
                     if complete { n += 1; }
                     Continuation::Continue

--- a/src/search.rs
+++ b/src/search.rs
@@ -1897,7 +1897,6 @@ mod tests {
 
     // --- search_all_alignments consistency tests ---
 
-    /// For each end position returned by `search_all`, verify that `search_all_alignments`:
     /// For each endpoint returned by `search_all`, verify that `search_all_alignments`:
     /// - produces exactly one group per endpoint (Fwd grouped by text_end, RC by text_start)
     /// - yields at least one alignment per group

--- a/src/search.rs
+++ b/src/search.rs
@@ -1960,65 +1960,70 @@ mod tests {
     }
 
     #[test]
-    fn search_all_alignments_consistent_rc() {
-        let rc = Dna::reverse_complement(b"ATCGATCA");
-        let text = [b"GGGGGGGG".as_ref(), rc.as_ref(), b"GGGGGGGG"].concat();
-        let mut s = Searcher::<Dna>::new(true, None);
-        assert_consistent_with_search_all(&mut s, b"ATCGATCA", &text, 0);
-    }
-
-    #[test]
     fn search_all_alignments_rc_fuzz() {
         use rand::rngs::StdRng;
         use rand::{RngExt, SeedableRng};
+
         let mut rng = StdRng::seed_from_u64(42);
         let bases = b"ACGT";
 
-        for _ in 0..1000 {
+        for _ in 0..500 {
             let plen = rng.random_range(4..=20);
             let tlen = rng.random_range(plen..=plen + 10);
             let k    = rng.random_range(0..=3usize);
 
             let pattern: Vec<u8> = (0..plen).map(|_| bases[rng.random_range(0..4usize)]).collect();
             let text:    Vec<u8> = (0..tlen).map(|_| bases[rng.random_range(0..4usize)]).collect();
+            let rc_text = Dna::reverse_complement(&text);
 
-            let mut searcher = Searcher::<Dna>::new(true, None);
-            let groups = searcher.search_all_alignments(&pattern, &text, k, false);
+            let groups     = Searcher::<Dna>::new(true,  None).search_all_alignments(&pattern, &text,    k, false);
+            let groups_fwd = Searcher::<Dna>::new(false, None).search_all_alignments(&pattern, &rc_text, k, false);
 
-            for group in &groups {
-                for m in group {
-                    assert!(
-                        m.cost as usize <= k,
-                        "cost {} > k={} for pattern={} text={}",
-                        m.cost, k,
-                        String::from_utf8_lossy(&pattern),
-                        String::from_utf8_lossy(&text),
-                    );
-                    if m.strand == Strand::Rc {
-                        assert!(
-                            m.text_start <= m.text_end,
-                            "RC match has text_start > text_end: {:?}", m
-                        );
-                        assert!(
-                            m.text_end <= text.len(),
-                            "RC match text_end out of bounds: {:?}", m
-                        );
-                    }
-                }
-            }
+            // Collect all RC matches as (text_start, text_end, cost, cigar).
+            // The RC search of P against T internally aligns P against RC(T), reporting
+            // coordinates back in T-space: rc_start -> tlen-rc_end, rc_end -> tlen-rc_start.
+            let mut rc_matches: Vec<(usize, usize, i32, String)> = groups.iter()
+                .flat_map(|g| g.iter())
+                .filter(|m| m.strand == Strand::Rc)
+                .map(|m| (m.text_start, m.text_end, m.cost, m.cigar.to_string()))
+                .collect();
+
+            // The equivalent fwd search of P against RC(T) produces matches in RC(T)-space.
+            // Transform [s', e') in RC(T) back to T-space: [tlen-e', tlen-s').
+            // CIGARs are identical because both compute the same alignment (P vs RC(T) segment).
+            let mut fwd_as_rc: Vec<(usize, usize, i32, String)> = groups_fwd.iter()
+                .flat_map(|g| g.iter())
+                .map(|m| (tlen - m.text_end, tlen - m.text_start, m.cost, m.cigar.to_string()))
+                .collect();
+
+            rc_matches.sort();
+            fwd_as_rc.sort();
+
+            assert_eq!(
+                rc_matches, fwd_as_rc,
+                "RC/fwd match mismatch: pattern={} text={} k={k}",
+                String::from_utf8_lossy(&pattern),
+                String::from_utf8_lossy(&text),
+            );
         }
     }
 
     #[test]
     fn search_all_alignments_consistent_fuzz() {
+        use rand::rngs::StdRng;
+        use rand::{RngExt, SeedableRng};
+
+        let mut rng = StdRng::seed_from_u64(42);
+        let bases = b"ACGT";
+
         let mut fwd_searcher = Searcher::<Dna>::new(false, None);
         let mut rc_searcher  = Searcher::<Dna>::new(true,  None);
         for _ in 0..200 {
-            let plen = random_range(3..20);
-            let tlen = random_range(plen..plen * 4);
-            let k = random_range(0..plen / 3 + 1);
-            let pattern: Vec<u8> = (0..plen).map(|_| b"ACGT"[random_range(0..4)]).collect();
-            let text: Vec<u8> = (0..tlen).map(|_| b"ACGT"[random_range(0..4)]).collect();
+            let plen = rng.random_range(3..20usize);
+            let tlen = rng.random_range(plen..plen * 4);
+            let k    = rng.random_range(0..plen / 3 + 1);
+            let pattern: Vec<u8> = (0..plen).map(|_| bases[rng.random_range(0..4usize)]).collect();
+            let text:    Vec<u8> = (0..tlen).map(|_| bases[rng.random_range(0..4usize)]).collect();
             eprintln!(
                 "pattern={} text={} k={k}",
                 String::from_utf8_lossy(&pattern),

--- a/src/search.rs
+++ b/src/search.rs
@@ -682,27 +682,35 @@ impl<P: Profile> Searcher<P> {
         k: usize,
         prune_suboptimal: bool,
     ) -> Vec<Vec<Match>> {
-        let fwd: Vec<Match> = self
-            .search_all(pattern, text, k)
-            .into_iter()
-            .filter(|m| m.strand == Strand::Fwd)
-            .collect();
+        let all_matches = self.search_all(pattern, text, k);
 
         let mut groups: Vec<Vec<Match>> = Vec::new();
-        let mut cur_end: Option<usize> = None;
+        let mut cur_fwd_end:  Option<usize> = None;
+        let mut cur_rc_start: Option<usize> = None;
 
         self.iterate_all_alignments(
             pattern,
             text,
             k,
-            &fwd,
+            &all_matches,
             false,
             prune_suboptimal,
             &mut |complete, m| {
                 if complete {
-                    if cur_end != Some(m.text_end) {
+                    let anchor_changed = match m.strand {
+                        Strand::Fwd => {
+                            let changed = cur_fwd_end != Some(m.text_end);
+                            cur_fwd_end = Some(m.text_end);
+                            changed
+                        }
+                        Strand::Rc => {
+                            let changed = cur_rc_start != Some(m.text_start);
+                            cur_rc_start = Some(m.text_start);
+                            changed
+                        }
+                    };
+                    if anchor_changed {
                         groups.push(Vec::new());
-                        cur_end = Some(m.text_end);
                     }
                     groups.last_mut().unwrap().push(m.clone());
                 }
@@ -1900,16 +1908,13 @@ mod tests {
     // --- search_all_alignments consistency tests ---
 
     /// For each end position returned by `search_all`, verify that `search_all_alignments`:
-    /// - produces exactly one group per end position
+    /// For each endpoint returned by `search_all`, verify that `search_all_alignments`:
+    /// - produces exactly one group per endpoint (Fwd grouped by text_end, RC by text_start)
     /// - yields at least one alignment per group
-    /// - all alignments in a group share the same `text_end`
-    /// - all alignments have cost ≤ k
-    /// - the first alignment matches the greedy traceback (`text_start` and CIGAR)
+    /// - all alignments share the anchor coordinate and have cost ≤ k
+    /// - the first alignment matches the greedy traceback (text_start and CIGAR)
     fn assert_consistent_with_search_all(searcher: &mut Searcher<Dna>, pattern: &[u8], text: &[u8], k: usize) {
-        let all_matches = searcher.search_all(pattern, text, k)
-            .into_iter()
-            .filter(|m| m.strand == Strand::Fwd)
-            .collect::<Vec<_>>();
+        let all_matches = searcher.search_all(pattern, text, k);
         let groups = searcher.search_all_alignments(pattern, text, k, false);
 
         // Endpoints with only leading-deletion paths produce no group, so groups.len() <= all_matches.len().
@@ -1936,7 +1941,11 @@ mod tests {
                 String::from_utf8_lossy(text),
             ));
             for m in group {
-                assert_eq!(m.text_end, expected.text_end, "all alignments in group must share text_end");
+                match expected.strand {
+                    Strand::Fwd => assert_eq!(m.text_end,   expected.text_end,   "all Fwd alignments in group must share text_end"),
+                    Strand::Rc  => assert_eq!(m.text_start, expected.text_start, "all RC alignments in group must share text_start"),
+                }
+                assert_eq!(m.strand, expected.strand, "strand must match search_all result");
                 assert!(m.cost <= k as i32, "alignment cost {} exceeds k={k}", m.cost);
             }
         }
@@ -1961,8 +1970,17 @@ mod tests {
     }
 
     #[test]
+    fn search_all_alignments_consistent_rc() {
+        let rc = Dna::reverse_complement(b"ATCGATCA");
+        let text = [b"GGGGGGGG".as_ref(), rc.as_ref(), b"GGGGGGGG"].concat();
+        let mut s = Searcher::<Dna>::new(true, None);
+        assert_consistent_with_search_all(&mut s, b"ATCGATCA", &text, 0);
+    }
+
+    #[test]
     fn search_all_alignments_consistent_fuzz() {
-        let mut searcher = Searcher::<Dna>::new(false, None);
+        let mut fwd_searcher = Searcher::<Dna>::new(false, None);
+        let mut rc_searcher  = Searcher::<Dna>::new(true,  None);
         for _ in 0..200 {
             let plen = random_range(3..20);
             let tlen = random_range(plen..plen * 4);
@@ -1974,7 +1992,8 @@ mod tests {
                 String::from_utf8_lossy(&pattern),
                 String::from_utf8_lossy(&text),
             );
-            assert_consistent_with_search_all(&mut searcher, &pattern, &text, k);
+            assert_consistent_with_search_all(&mut fwd_searcher, &pattern, &text, k);
+            assert_consistent_with_search_all(&mut rc_searcher,  &pattern, &text, k);
         }
     }
 


### PR DESCRIPTION
This PR enables iteration over reverse-complement alignments, and adds a fuzzing test.

I believe I've now addressed all feedback from an earlier [TimD1/sassy PR 3](https://github.com/TimD1/sassy/pull/3) and [discussion here](https://github.com/RagnarGrootKoerkamp/sassy/pull/48#issuecomment-4212787014).