### PR TITLE
Additional pruning (unconditionally)

### DIFF
--- a/src/alignment_iterator.rs
+++ b/src/alignment_iterator.rs
@@ -22,6 +22,19 @@ pub enum Continuation {
     Break,
 }
 
+fn net_insertions_since_last_match(cigar: &Cigar) -> i32 {
+    let mut net = 0i32;
+    for elem in cigar.ops.iter().rev() {
+        match elem.op {
+            CigarOp::Match => break,
+            CigarOp::Ins   => net += elem.cnt,
+            CigarOp::Del   => net -= elem.cnt,
+            CigarOp::Sub   => {} // ignore
+        }
+    }
+    net
+}
+
 /// (match_is_complete, (partial) match) -> continuation.
 pub trait Callback: FnMut(bool, &mut Match) -> Continuation {}
 
@@ -289,6 +302,13 @@ impl<'s, C: Callback> Context<'s, C> {
                         }
                     }
                 }
+
+                // We may not have both inserted and deleted bases since the last match
+                // NB: This forces taking a diagonal path (subs) wherever possible
+                let net_ins = net_insertions_since_last_match(&self.m.cigar);
+                if (op == CigarOp::Ins && net_ins < 0) || (op == CigarOp::Del && net_ins > 0)  {
+                    continue;
+                }
             }
 
             edges.push((op, total_cost));
@@ -296,6 +316,7 @@ impl<'s, C: Callback> Context<'s, C> {
 
         // Stable sort edges by total cost, preferring match/sub in case of ties.
         edges.sort_by_key(|(_, cost)| *cost);
+
 
         for (op, _cost) in edges {
             let delta = op.delta();
@@ -331,5 +352,46 @@ impl<'s, C: Callback> Context<'s, C> {
         }
 
         Continuation::Continue
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::net_insertions_since_last_match;
+    use pa_types::{Cigar, CigarOp};
+    use CigarOp::{Del as D, Ins as I, Match as M, Sub as X};
+
+    fn cigar(ops: &[pa_types::CigarOp]) -> Cigar {
+        let mut c = Cigar::default();
+        for &op in ops {
+            c.push(op);
+        }
+        c
+    }
+
+    #[test]
+    fn net_insertions_since_last_match_cases() {
+        let cases: &[(&[pa_types::CigarOp], i32)] = &[
+            (&[],                  0),  // empty cigar
+            (&[M],                 0),  // match resets immediately
+            (&[I, I, I],           3),  // all insertions, no anchor
+            (&[D, D],             -2),  // all deletions, no anchor
+            (&[M, I, I],           2),  // two I's after match
+            (&[M, D, D],          -2),  // two D's after match
+            (&[M, I, I, D],        1),  // net 2I − 1D
+            (&[M, I, I, D, D],     0),  // balanced
+            (&[I, X, D],           0),  // X is transparent: +1 − 1
+            (&[M, I, X, D],        0),  // X between I and D, after anchor
+            (&[M, X, X, I],        1),  // X's skipped, only I counted
+            (&[I, I, M, D, D],    -2),  // stop at M, only trailing DD visible
+            (&[M, D, M, I, I],     2),  // stop at second M, see II
+        ];
+        for &(ops, expected) in cases {
+            assert_eq!(
+                net_insertions_since_last_match(&cigar(ops)),
+                expected,
+                "ops = {ops:?}"
+            );
+        }
     }
 }

--- a/src/alignment_iterator.rs
+++ b/src/alignment_iterator.rs
@@ -49,10 +49,6 @@ impl<P: Profile> Searcher<P> {
     /// forward-text coordinates before the callback fires.
     ///
     /// If `partial_matches` is `true`, the callback is called for *every* visited DFS state.
-    ///
-    /// If `prune_suboptimal` is `true`, path for which some part can be replaced by exact matches are skipped.
-    /// E.g., if `====` is an option, this will skip over `=I=D=`, and similarly, this will prefer `===...` over `=I=...`.
-    #[allow(clippy::too_many_arguments)]
     pub fn iterate_all_alignments<I: RcSearchAble + ?Sized>(
         &self,
         pattern: &[u8],
@@ -60,7 +56,6 @@ impl<P: Profile> Searcher<P> {
         k: usize,
         matches: &mut [Match],
         partial_matches: bool,
-        prune_suboptimal: bool,
         callback: &mut impl Callback,
     ) {
         assert_eq!(self.alpha, None, "Tracing all alignments with overhang is not yet implemented.");
@@ -74,7 +69,7 @@ impl<P: Profile> Searcher<P> {
 
         // --- Forward strand ---
         if !fwd.is_empty() {
-            self.iterate_one_strand(pattern, fwd_text, k, fwd, partial_matches, prune_suboptimal, callback, None);
+            self.iterate_one_strand(pattern, fwd_text, k, fwd, partial_matches, callback, None);
         }
 
         // --- Reverse-complement strand ---
@@ -102,12 +97,11 @@ impl<P: Profile> Searcher<P> {
             // RC matches are in fwd coords; pass flip=Some(fwd_len) so iterate_one_strand
             // derives rev-text endpoints on the fly without mutating the slice.
             self.iterate_one_strand(&comp_pattern, rev_text, k, rc,
-                                    partial_matches, prune_suboptimal, &mut rc_callback,
+                                    partial_matches, &mut rc_callback,
                                     Some(fwd_len));
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn iterate_one_strand(
         &self,
         pattern: &[u8],
@@ -115,7 +109,6 @@ impl<P: Profile> Searcher<P> {
         k: usize,
         matches: &[Match],
         partial_matches: bool,
-        prune_suboptimal: bool,
         callback: &mut impl Callback,
         flip: Option<usize>,
     ) {
@@ -204,7 +197,6 @@ impl<P: Profile> Searcher<P> {
                     m,
                     k,
                     partial_matches,
-                    prune_suboptimal,
                     callback,
                     last_row_in_diagonal,
                 };
@@ -222,7 +214,6 @@ struct Context<'s, C: Callback> {
     m: &'s mut Match,
     k: usize,
     partial_matches: bool,
-    prune_suboptimal: bool,
     callback: &'s mut C,
     last_row_in_diagonal: &'s mut Vec<pa_types::I>,
 }
@@ -273,42 +264,40 @@ impl<'s, C: Callback> Context<'s, C> {
                 continue;
             }
 
-            if self.prune_suboptimal {
-                // We may not *leave* a diagonal if it can be extended by exact matches to the top of the matrix.
-                if op == CigarOp::Ins || op == CigarOp::Del {
-                    let pat_slice = &self.pattern[..pos.1 as usize];
-                    let text_slice = &self.text[(pos.0 - pos.1).max(0) as usize..pos.0 as usize];
+            // We may not *leave* a diagonal if it can be extended by exact matches to the top of the matrix.
+            if op == CigarOp::Ins || op == CigarOp::Del {
+                let pat_slice = &self.pattern[..pos.1 as usize];
+                let text_slice = &self.text[(pos.0 - pos.1).max(0) as usize..pos.0 as usize];
+                if P::is_match_slice(pat_slice, text_slice) {
+                    continue;
+                }
+            }
+
+            // We may not *enter* a diagonal if it was reachable by exact matches from either:
+            // - the bottom of the matrix, or
+            // - the last time we were in this diagonal.
+            if op == CigarOp::Ins || op == CigarOp::Del {
+                // The last (most recent) row we visited in the `new_pos` diagonal.
+                // Defaults to `pattern.len()` for bottom of the matrix.
+                let last_in_diag = self.last_row_in_diagonal[new_pos.0 as usize
+                    + self.pattern.len()
+                    - self.range_start
+                    - new_pos.1 as usize];
+                let pat_slice = &self.pattern[new_pos.1 as usize..last_in_diag as usize];
+                let text_end = new_pos.0 as usize + pat_slice.len();
+                if text_end <= self.text.len() {
+                    let text_slice = &self.text[new_pos.0 as usize..text_end];
                     if P::is_match_slice(pat_slice, text_slice) {
                         continue;
                     }
                 }
+            }
 
-                // We may not *enter* a diagonal if it was reachable by exact matches from either:
-                // - the bottom of the matrix, or
-                // - the last time we were in this diagonal.
-                if op == CigarOp::Ins || op == CigarOp::Del {
-                    // The last (most recent) row we visited in the `new_pos` diagonal.
-                    // Defaults to `pattern.len()` for bottom of the matrix.
-                    let last_in_diag = self.last_row_in_diagonal[new_pos.0 as usize
-                        + self.pattern.len()
-                        - self.range_start
-                        - new_pos.1 as usize];
-                    let pat_slice = &self.pattern[new_pos.1 as usize..last_in_diag as usize];
-                    let text_end = new_pos.0 as usize + pat_slice.len();
-                    if text_end <= self.text.len() {
-                        let text_slice = &self.text[new_pos.0 as usize..text_end];
-                        if P::is_match_slice(pat_slice, text_slice) {
-                            continue;
-                        }
-                    }
-                }
-
-                // We may not have both inserted and deleted bases since the last match
-                // NB: This forces taking a diagonal path (subs) wherever possible
-                let net_ins = net_insertions_since_last_match(&self.m.cigar);
-                if (op == CigarOp::Ins && net_ins < 0) || (op == CigarOp::Del && net_ins > 0)  {
-                    continue;
-                }
+            // We may not have both inserted and deleted bases since the last match
+            // NB: This forces taking a diagonal path (subs) wherever possible
+            let net_ins = net_insertions_since_last_match(&self.m.cigar);
+            if (op == CigarOp::Ins && net_ins < 0) || (op == CigarOp::Del && net_ins > 0)  {
+                continue;
             }
 
             edges.push((op, total_cost));

--- a/src/python.rs
+++ b/src/python.rs
@@ -102,7 +102,7 @@ impl Searcher {
         }
     }
 
-    #[pyo3(signature = (pattern, text, k, prune_suboptimal=false))]
+    #[pyo3(signature = (pattern, text, k, prune_suboptimal=false, max_n_frac=0.2))]
     #[doc = "Enumerate all alignments at every end position with cost <= k.\n\
              Returns a list of groups; each group is a list of Matches sharing the same anchor coordinate.\n\
              For Fwd matches the anchor is text_end; for RC matches the anchor is text_start."]
@@ -112,13 +112,14 @@ impl Searcher {
         text: &Bound<'_, PyBytes>,
         k: usize,
         prune_suboptimal: bool,
+        max_n_frac: f32,
     ) -> Vec<Vec<Match>> {
         let pattern = pattern.as_bytes();
         let text = text.as_bytes();
         match &mut self.searcher {
-            SearcherType::Ascii(s) => s.search_all_alignments(pattern, text, k, prune_suboptimal),
-            SearcherType::Dna(s) => s.search_all_alignments(pattern, text, k, prune_suboptimal),
-            SearcherType::Iupac(s) => s.search_all_alignments(pattern, text, k, prune_suboptimal),
+            SearcherType::Ascii(s) => s.search_all_alignments(pattern, text, k, prune_suboptimal, max_n_frac),
+            SearcherType::Dna(s) => s.search_all_alignments(pattern, text, k, prune_suboptimal, max_n_frac),
+            SearcherType::Iupac(s) => s.search_all_alignments(pattern, text, k, prune_suboptimal, max_n_frac),
         }
     }
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -102,7 +102,7 @@ impl Searcher {
         }
     }
 
-    #[pyo3(signature = (pattern, text, k, prune_suboptimal=false, max_n_frac=0.2))]
+    #[pyo3(signature = (pattern, text, k, max_n_frac=0.2))]
     #[doc = "Enumerate all alignments at every end position with cost <= k.\n\
              Returns a list of groups; each group is a list of Matches sharing the same anchor coordinate.\n\
              For Fwd matches the anchor is text_end; for RC matches the anchor is text_start."]
@@ -111,15 +111,14 @@ impl Searcher {
         pattern: &Bound<'_, PyBytes>,
         text: &Bound<'_, PyBytes>,
         k: usize,
-        prune_suboptimal: bool,
         max_n_frac: f32,
     ) -> Vec<Vec<Match>> {
         let pattern = pattern.as_bytes();
         let text = text.as_bytes();
         match &mut self.searcher {
-            SearcherType::Ascii(s) => s.search_all_alignments(pattern, text, k, prune_suboptimal, max_n_frac),
-            SearcherType::Dna(s) => s.search_all_alignments(pattern, text, k, prune_suboptimal, max_n_frac),
-            SearcherType::Iupac(s) => s.search_all_alignments(pattern, text, k, prune_suboptimal, max_n_frac),
+            SearcherType::Ascii(s) => s.search_all_alignments(pattern, text, k, max_n_frac),
+            SearcherType::Dna(s) => s.search_all_alignments(pattern, text, k, max_n_frac),
+            SearcherType::Iupac(s) => s.search_all_alignments(pattern, text, k, max_n_frac),
         }
     }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -1940,8 +1940,8 @@ mod tests {
             let text:    Vec<u8> = (0..tlen).map(|_| bases[rng.random_range(0..4usize)]).collect();
             let rc_text = Dna::reverse_complement(&text);
 
-            let groups     = Searcher::<Dna>::new(true,  None).search_all_alignments(&pattern, &text,    k, false);
-            let groups_fwd = Searcher::<Dna>::new(false, None).search_all_alignments(&pattern, &rc_text, k, false);
+            let groups     = Searcher::<Dna>::new(true,  None).search_all_alignments(&pattern, &text,    k, 1.0);
+            let groups_fwd = Searcher::<Dna>::new(false, None).search_all_alignments(&pattern, &rc_text, k, 1.0);
 
             // Collect all RC matches as (text_start, text_end, cost, cigar).
             // The RC search of P against T internally aligns P against RC(T), reporting

--- a/src/search.rs
+++ b/src/search.rs
@@ -691,7 +691,6 @@ impl<P: Profile> Searcher<P> {
             k,
             &mut all_matches,
             false,
-            true,
             &mut |complete, m: &mut Match| {
                 if complete {
                     flat.push(m.clone());
@@ -1763,7 +1762,7 @@ mod tests {
             .filter(|m| m.strand == Strand::Fwd)
             .collect();
         searcher.iterate_all_alignments(
-            pattern, text, k, &mut fwd, false, false,
+            pattern, text, k, &mut fwd, false,
             &mut |complete, _m| {
                 assert!(complete, "callback fired for incomplete match with partial_matches=false");
                 Continuation::Continue
@@ -1783,7 +1782,7 @@ mod tests {
             .filter(|m| m.strand == Strand::Fwd)
             .collect();
         let mut saw_partial = false;
-        searcher.iterate_all_alignments(pattern, text, k, &mut fwd, true, false, &mut |complete, m| {
+        searcher.iterate_all_alignments(pattern, text, k, &mut fwd, true, &mut |complete, m| {
             if !complete {
                 saw_partial = true;
                 assert!(m.pattern_start > 0, "incomplete match should have pattern_start > 0");
@@ -1798,7 +1797,7 @@ mod tests {
         let searcher = Searcher::<Dna>::new(false, None);
         let mut called = false;
         searcher.iterate_all_alignments(
-            b"ACGT", b"ACGT", 1, &mut [], false, false,
+            b"ACGT", b"ACGT", 1, &mut [], false,
             &mut |_complete, _m| {
                 called = true;
                 Continuation::Continue
@@ -3455,12 +3454,12 @@ mod tests {
         let text = b"AAAAAAA";
         let k = 2;
 
-        let count = |pattern: &[u8], prune: bool| -> usize {
+        let count = |pattern: &[u8]| -> usize {
             let mut searcher = Searcher::<Iupac>::new(false, None);
             let mut matches = searcher.search_all(pattern, text, k);
             let mut n = 0;
             searcher.iterate_all_alignments(
-                pattern, text, k, &mut matches, false, prune,
+                pattern, text, k, &mut matches, false,
                 &mut |complete, _| {
                     if complete { n += 1; }
                     Continuation::Continue
@@ -3470,9 +3469,9 @@ mod tests {
         };
 
         assert_eq!(
-            count(b"NAAA", true),
-            count(b"AAAA", true),
-            "prune_suboptimal must use Profile::is_match, not raw ==, to handle N-containing patterns"
+            count(b"NAAA"),
+            count(b"AAAA"),
+            "must use Profile::is_match, not raw ==, to handle N-containing patterns"
         );
     }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -681,6 +681,7 @@ impl<P: Profile> Searcher<P> {
         text: &I,
         k: usize,
         prune_suboptimal: bool,
+        max_n_frac: f32,
     ) -> Vec<Vec<Match>> {
         let mut all_matches = self.search_all(pattern, text, k);
 
@@ -699,6 +700,14 @@ impl<P: Profile> Searcher<P> {
                 Continuation::Continue
             },
         );
+
+        let fwd_text = text.text();
+        let fwd_text = fwd_text.as_ref();
+        flat.retain(|m| {
+            let slice = &fwd_text[m.text_start..m.text_end];
+            let n_count = slice.iter().filter(|&&c| c.to_ascii_uppercase() == b'N').count() as f32;
+            n_count / slice.len() as f32 <= max_n_frac
+        });
 
         let anchor_key = |m: &Match| -> (Strand, usize) {
             match m.strand {
@@ -1671,7 +1680,7 @@ mod tests {
 
     #[test]
     fn exact_match() {
-        let groups = Searcher::<Dna>::new(false, None).search_all_alignments(b"ACGT", b"ACGT", 0, false);
+        let groups = Searcher::<Dna>::new(false, None).search_all_alignments(b"ACGT", b"ACGT", 0, false, 1.0);
         assert_eq!(groups.len(), 1);
         let m = &groups[0][0];
         assert_eq!(m.cost, 0);
@@ -1684,13 +1693,13 @@ mod tests {
 
     #[test]
     fn no_match() {
-        let groups = Searcher::<Dna>::new(false, None).search_all_alignments(b"ACGT", b"TTTT", 2, false);
+        let groups = Searcher::<Dna>::new(false, None).search_all_alignments(b"ACGT", b"TTTT", 2, false, 1.0);
         assert_eq!(groups.len(), 0);
     }
 
     #[test]
     fn multiple_alignments_one_end() {
-        let groups = Searcher::<Dna>::new(false, None).search_all_alignments(b"AT", b"ACT", 1, false);
+        let groups = Searcher::<Dna>::new(false, None).search_all_alignments(b"AT", b"ACT", 1, false, 1.0);
         let multi: Vec<_> = groups.iter().filter(|g| g.len() > 1).collect();
         assert_eq!(multi.len(), 1, "expected exactly one end position with >1 alignment");
         let aligns = multi[0];
@@ -1707,7 +1716,7 @@ mod tests {
 
     #[test]
     fn multiple_end_positions() {
-        let groups = Searcher::<Dna>::new(false, None).search_all_alignments(b"AA", b"AAAA", 0, false);
+        let groups = Searcher::<Dna>::new(false, None).search_all_alignments(b"AA", b"AAAA", 0, false, 1.0);
         assert_eq!(groups.len(), 3, "expected three end positions, got {}", groups.len());
         for group in &groups {
             assert_eq!(group.len(), 1);
@@ -1721,7 +1730,7 @@ mod tests {
     #[test]
     fn complete_matches_span_full_pattern() {
         let pattern = b"ACGT";
-        let groups = Searcher::<Dna>::new(false, None).search_all_alignments(pattern, b"AACGTT", 2, false);
+        let groups = Searcher::<Dna>::new(false, None).search_all_alignments(pattern, b"AACGTT", 2, false, 1.0);
         assert!(!groups.is_empty());
         for group in &groups {
             for m in group {
@@ -1737,7 +1746,7 @@ mod tests {
         let k = 3usize;
         let pattern = vec![b'A'; t + k];
         let text = vec![b'A'; t];
-        let groups = Searcher::<Dna>::new(false, None).search_all_alignments(&pattern, &text, k, false);
+        let groups = Searcher::<Dna>::new(false, None).search_all_alignments(&pattern, &text, k, false, 1.0);
         let total: usize = groups.iter().map(|g| g.len()).sum();
         // C(8, 3) = 56
         assert_eq!(total, 56, "expected C(8,3)=56 alignments, got {total}");
@@ -1804,8 +1813,8 @@ mod tests {
         let pattern = b"AAAA";
         let text = b"AAAAAA";
         let k = 2;
-        let full = Searcher::<Dna>::new(false, None).search_all_alignments(pattern, text, k, false);
-        let pruned = Searcher::<Dna>::new(false, None).search_all_alignments(pattern, text, k, true);
+        let full = Searcher::<Dna>::new(false, None).search_all_alignments(pattern, text, k, false, 1.0);
+        let pruned = Searcher::<Dna>::new(false, None).search_all_alignments(pattern, text, k, true, 1.0);
         let full_total: usize = full.iter().map(|g| g.len()).sum();
         let pruned_total: usize = pruned.iter().map(|g| g.len()).sum();
         // Exact counts: 97 unpruned (leading- and trailing-deletion paths excluded); 3 pruned (one per end at text_end=4,5,6).
@@ -1838,7 +1847,7 @@ mod tests {
         let text = b"XACGTX";
         let k = 1;
         for &rc in &[false, true] {
-            let groups = Searcher::<Dna>::new(rc, None).search_all_alignments(pattern, text, k, false);
+            let groups = Searcher::<Dna>::new(rc, None).search_all_alignments(pattern, text, k, false, 1.0);
             for group in &groups {
                 for m in group {
                     let cigar = m.cigar.to_string();
@@ -1870,8 +1879,8 @@ mod tests {
             (b"AA", b"AAAA", 1),
         ];
         for &(pattern, text, k) in cases {
-            let full = Searcher::<Dna>::new(false, None).search_all_alignments(pattern, text, k, false);
-            let pruned = Searcher::<Dna>::new(false, None).search_all_alignments(pattern, text, k, true);
+            let full = Searcher::<Dna>::new(false, None).search_all_alignments(pattern, text, k, false, 1.0);
+            let pruned = Searcher::<Dna>::new(false, None).search_all_alignments(pattern, text, k, true, 1.0);
             for pruned_group in &pruned {
                 let end = pruned_group[0].text_end;
                 let full_group = full
@@ -1904,7 +1913,7 @@ mod tests {
     /// - the first alignment matches the greedy traceback (text_start and CIGAR)
     fn assert_consistent_with_search_all(searcher: &mut Searcher<Dna>, pattern: &[u8], text: &[u8], k: usize) {
         let all_matches = searcher.search_all(pattern, text, k);
-        let groups = searcher.search_all_alignments(pattern, text, k, false);
+        let groups = searcher.search_all_alignments(pattern, text, k, false, 1.0);
 
         // Endpoints with only leading-deletion paths produce no group, so groups.len() <= all_matches.len().
         assert!(
@@ -2031,6 +2040,20 @@ mod tests {
             assert_consistent_with_search_all(&mut fwd_searcher, &pattern, &text, k);
             assert_consistent_with_search_all(&mut rc_searcher,  &pattern, &text, k);
         }
+    }
+
+    #[test]
+    fn n_frac_filtering() {
+        // Iupac profile handles N bases in the aligned region.
+        // max_n_frac=0.0: all-N aligned region must be rejected.
+        let groups = Searcher::<Iupac>::new(false, None)
+            .search_all_alignments(b"ACGT", b"NNNN", 4, false, 0.0);
+        assert!(groups.is_empty(), "expected no groups when all bases are N and max_n_frac=0.0");
+
+        // max_n_frac=1.0: same query should produce matches.
+        let groups = Searcher::<Iupac>::new(false, None)
+            .search_all_alignments(b"ACGT", b"NNNN", 4, false, 1.0);
+        assert!(!groups.is_empty(), "expected groups when N filtering is disabled (max_n_frac=1.0)");
     }
 
     #[test]

--- a/src/search.rs
+++ b/src/search.rs
@@ -680,7 +680,6 @@ impl<P: Profile> Searcher<P> {
         pattern: &[u8],
         text: &I,
         k: usize,
-        prune_suboptimal: bool,
         max_n_frac: f32,
     ) -> Vec<Vec<Match>> {
         let mut all_matches = self.search_all(pattern, text, k);
@@ -692,7 +691,7 @@ impl<P: Profile> Searcher<P> {
             k,
             &mut all_matches,
             false,
-            prune_suboptimal,
+            true,
             &mut |complete, m: &mut Match| {
                 if complete {
                     flat.push(m.clone());
@@ -1680,7 +1679,7 @@ mod tests {
 
     #[test]
     fn exact_match() {
-        let groups = Searcher::<Dna>::new(false, None).search_all_alignments(b"ACGT", b"ACGT", 0, false, 1.0);
+        let groups = Searcher::<Dna>::new(false, None).search_all_alignments(b"ACGT", b"ACGT", 0, 1.0);
         assert_eq!(groups.len(), 1);
         let m = &groups[0][0];
         assert_eq!(m.cost, 0);
@@ -1693,13 +1692,13 @@ mod tests {
 
     #[test]
     fn no_match() {
-        let groups = Searcher::<Dna>::new(false, None).search_all_alignments(b"ACGT", b"TTTT", 2, false, 1.0);
+        let groups = Searcher::<Dna>::new(false, None).search_all_alignments(b"ACGT", b"TTTT", 2, 1.0);
         assert_eq!(groups.len(), 0);
     }
 
     #[test]
     fn multiple_alignments_one_end() {
-        let groups = Searcher::<Dna>::new(false, None).search_all_alignments(b"AT", b"ACT", 1, false, 1.0);
+        let groups = Searcher::<Dna>::new(false, None).search_all_alignments(b"AT", b"ACT", 1, 1.0);
         let multi: Vec<_> = groups.iter().filter(|g| g.len() > 1).collect();
         assert_eq!(multi.len(), 1, "expected exactly one end position with >1 alignment");
         let aligns = multi[0];
@@ -1716,7 +1715,7 @@ mod tests {
 
     #[test]
     fn multiple_end_positions() {
-        let groups = Searcher::<Dna>::new(false, None).search_all_alignments(b"AA", b"AAAA", 0, false, 1.0);
+        let groups = Searcher::<Dna>::new(false, None).search_all_alignments(b"AA", b"AAAA", 0, 1.0);
         assert_eq!(groups.len(), 3, "expected three end positions, got {}", groups.len());
         for group in &groups {
             assert_eq!(group.len(), 1);
@@ -1730,7 +1729,7 @@ mod tests {
     #[test]
     fn complete_matches_span_full_pattern() {
         let pattern = b"ACGT";
-        let groups = Searcher::<Dna>::new(false, None).search_all_alignments(pattern, b"AACGTT", 2, false, 1.0);
+        let groups = Searcher::<Dna>::new(false, None).search_all_alignments(pattern, b"AACGTT", 2, 1.0);
         assert!(!groups.is_empty());
         for group in &groups {
             for m in group {
@@ -1746,7 +1745,7 @@ mod tests {
         let k = 3usize;
         let pattern = vec![b'A'; t + k];
         let text = vec![b'A'; t];
-        let groups = Searcher::<Dna>::new(false, None).search_all_alignments(&pattern, &text, k, false, 1.0);
+        let groups = Searcher::<Dna>::new(false, None).search_all_alignments(&pattern, &text, k, 1.0);
         let total: usize = groups.iter().map(|g| g.len()).sum();
         // C(8, 3) = 56
         assert_eq!(total, 56, "expected C(8,3)=56 alignments, got {total}");
@@ -1813,19 +1812,13 @@ mod tests {
         let pattern = b"AAAA";
         let text = b"AAAAAA";
         let k = 2;
-        let full = Searcher::<Dna>::new(false, None).search_all_alignments(pattern, text, k, false, 1.0);
-        let pruned = Searcher::<Dna>::new(false, None).search_all_alignments(pattern, text, k, true, 1.0);
-        let full_total: usize = full.iter().map(|g| g.len()).sum();
-        let pruned_total: usize = pruned.iter().map(|g| g.len()).sum();
-        // Exact counts: 97 unpruned (leading- and trailing-deletion paths excluded); 3 pruned (one per end at text_end=4,5,6).
-        assert_eq!(full_total, 97, "unexpected full alignment count");
-        assert_eq!(pruned_total, 3, "unexpected pruned alignment count");
-        for group in &pruned {
-            assert_eq!(group.len(), 1, "expected exactly 1 alignment per text_end with prune=true, got {}", group.len());
-        }
-        for group in &pruned {
+        let groups = Searcher::<Dna>::new(false, None).search_all_alignments(pattern, text, k, 1.0);
+        // One group per end position (text_end=4,5,6), each with exactly one exact-match alignment.
+        assert_eq!(groups.iter().map(|g| g.len()).sum::<usize>(), 3, "unexpected alignment count");
+        for group in &groups {
+            assert_eq!(group.len(), 1, "expected exactly 1 alignment per text_end, got {}", group.len());
             let m = &group[0];
-            assert_eq!(m.cost, 0, "expected cost 0 for pruned homopolymer alignment, got {}", m.cost);
+            assert_eq!(m.cost, 0, "expected cost 0 for homopolymer alignment, got {}", m.cost);
             assert_eq!(
                 m.text_end - m.text_start,
                 m.pattern_end - m.pattern_start,
@@ -1847,7 +1840,7 @@ mod tests {
         let text = b"XACGTX";
         let k = 1;
         for &rc in &[false, true] {
-            let groups = Searcher::<Dna>::new(rc, None).search_all_alignments(pattern, text, k, false, 1.0);
+            let groups = Searcher::<Dna>::new(rc, None).search_all_alignments(pattern, text, k, 1.0);
             for group in &groups {
                 for m in group {
                     let cigar = m.cigar.to_string();
@@ -1868,42 +1861,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn pruned_is_subset_of_full() {
-        use std::collections::HashSet;
-        let cases: &[(&[u8], &[u8], usize)] = &[
-            (b"AAAA", b"AAAAAA", 2),
-            (b"TTTT", b"AAAAAA", 2),
-            (b"ACGT", b"AACGTT", 2),
-            (b"AT", b"ACT", 1),
-            (b"AA", b"AAAA", 1),
-        ];
-        for &(pattern, text, k) in cases {
-            let full = Searcher::<Dna>::new(false, None).search_all_alignments(pattern, text, k, false, 1.0);
-            let pruned = Searcher::<Dna>::new(false, None).search_all_alignments(pattern, text, k, true, 1.0);
-            for pruned_group in &pruned {
-                let end = pruned_group[0].text_end;
-                let full_group = full
-                    .iter()
-                    .find(|g| g[0].text_end == end)
-                    .unwrap_or_else(|| panic!("pruned group at text_end={end} has no corresponding full group"));
-                let full_keys: HashSet<(usize, String)> = full_group
-                    .iter()
-                    .map(|m| (m.text_start, m.cigar.to_string()))
-                    .collect();
-                for m in pruned_group {
-                    assert!(
-                        full_keys.contains(&(m.text_start, m.cigar.to_string())),
-                        "pruned alignment not found in full set: pattern={} text={} k={k} text_end={end} cigar={}",
-                        std::str::from_utf8(pattern).unwrap(),
-                        std::str::from_utf8(text).unwrap(),
-                        m.cigar.to_string()
-                    );
-                }
-            }
-        }
-    }
-
     // --- search_all_alignments consistency tests ---
 
     /// For each endpoint returned by `search_all`, verify that `search_all_alignments`:
@@ -1913,7 +1870,7 @@ mod tests {
     /// - the first alignment matches the greedy traceback (text_start and CIGAR)
     fn assert_consistent_with_search_all(searcher: &mut Searcher<Dna>, pattern: &[u8], text: &[u8], k: usize) {
         let all_matches = searcher.search_all(pattern, text, k);
-        let groups = searcher.search_all_alignments(pattern, text, k, false, 1.0);
+        let groups = searcher.search_all_alignments(pattern, text, k, 1.0);
 
         // Endpoints with only leading-deletion paths produce no group, so groups.len() <= all_matches.len().
         assert!(
@@ -2047,12 +2004,12 @@ mod tests {
         // Iupac profile handles N bases in the aligned region.
         // max_n_frac=0.0: all-N aligned region must be rejected.
         let groups = Searcher::<Iupac>::new(false, None)
-            .search_all_alignments(b"ACGT", b"NNNN", 4, false, 0.0);
+            .search_all_alignments(b"ACGT", b"NNNN", 4, 0.0);
         assert!(groups.is_empty(), "expected no groups when all bases are N and max_n_frac=0.0");
 
         // max_n_frac=1.0: same query should produce matches.
         let groups = Searcher::<Iupac>::new(false, None)
-            .search_all_alignments(b"ACGT", b"NNNN", 4, false, 1.0);
+            .search_all_alignments(b"ACGT", b"NNNN", 4, 1.0);
         assert!(!groups.is_empty(), "expected groups when N filtering is disabled (max_n_frac=1.0)");
     }
 


### PR DESCRIPTION
### Summary
This PR makes 3 major changes:
1. Prunes alignments where insertions + deletions are used and a substitution could have been used instead.
2. Filters alignments where the text contains too many Ns (adding `--max_n_frac`)
3. Drops support for `prune_suboptimal = False`. Pruning now always occurs.