### PR TITLE
Adding R bindings to sassy

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Feature highlights:
 - Support for (case-insensitive) ASCII, DNA (`ACGT`), and
   [IUPAC](https://www.bioinformatics.org/sms/iupac.html) (=`ACGT+NYR...`) alphabets.
 - Rust library (`cargo add sassy`), binary (`cargo install sassy`, see details below), Python
-  bindings (`pip install sassy-rs`), and C bindings (see below).
+  bindings (`pip install sassy-rs`), R bindings ([`Rsassy`](https://github.com/sounkou-bioinfo/Rsassy)),
+  and C bindings (see below).
 
 See **the papers**, [detailed docs on docs.rs](https://docs.rs/sassy/latest/sassy/), and corresponding evals in [evals/](evals/):
 
@@ -87,7 +88,7 @@ Sassy requires Rust 1.91 or newer. Get it via `rustup update`. (Switch to
 
 ## Usage
 
-Sassy can be used via the CLI, or as Rust, Python, or C library.
+Sassy can be used via the CLI, or as Rust, Python, R, or C library.
 
 ### 0. Rust library
 
@@ -310,7 +311,12 @@ for m in matches:
 
 See [python/README.md](python/README.md) for more details.
 
-### 3. C library
+### 3. R bindings
+
+R bindings are maintained separately in [`Rsassy`](https://github.com/sounkou-bioinfo/Rsassy).
+See the [Rsassy package site](https://sounkou-bioinfo.github.io/Rsassy/) for installation and examples.
+
+### 4. C library
 
 See [c/README.md](c/README.md) for details. Quick example:
 


### PR DESCRIPTION
Hi,

Thanks for this great crate ! This pull request adds two distinct R bindings using the sassy create. A more idiomatic [extendr](https://github.com/extendr/extendr) based R binding and a more traditional Rust+ R's C API approach. The second approach allows us more facilities like reading bytes from R connections and greater performance (see benchmark results compared to wrapping the python library in R). 


Feel free to ignore this pull request if it is out of scope. It is put as draft to see if it is of interest within the upstream repo


**LLM usage**: The code and documentation were written with Codex 5.5 xhigh within Pi coding Agent. We take responsibility of the output after testing and benchmark results. 



Rsassy, sassyRS, and Python binding benchmark
================

- [Machine and build details](#machine-and-build-details)
- [Input data](#input-data)
- [Benchmarked calls](#benchmarked-calls)
- [Summary](#summary)

This report compares the R-facing overhead of three bindings to `sassy`:

- **Rsassy**: R bindings through R’s native C API.
- **sassyRS**: an `extendr` prototype.
- **Python sassy via reticulate**: the published `sassy-rs` Python
  binding called from R with `reticulate`.

The benchmark uses a deterministic 1 Mbp DNA text by default, not the
tiny toy string used in examples. Exact and two-mismatch copies of the
query are inserted every 100 kbp so each binding has real matches to
return.

## Machine and build details

The native benchmark build is expected to be installed before rendering
with:

``` bash
RUSTFLAGS="-C target-cpu=native" SASSY_RUST_FEATURES=native-simd R CMD INSTALL r/Rsassy
RUSTFLAGS="-C target-cpu=native" SASSY_RUST_FEATURES=native-simd R CMD INSTALL r/sassyRS
uv venv --python 3.11 .venv-benchmark
uv pip install --python .venv-benchmark sassy-rs
export RETICULATE_PYTHON="$PWD/.venv-benchmark/bin/python"
```

| field               | value                                                  |
|:--------------------|:-------------------------------------------------------|
| system              | Linux                                                  |
| release             | 6.8.0-78-generic                                       |
| machine             | x86_64                                                 |
| cpu_model           | 13th Gen Intel(R) Core(TM) i5-13500                    |
| R                   | R version 4.6.0 (2026-04-24)                           |
| platform            | x86_64-pc-linux-gnu                                    |
| RUSTFLAGS           | -C target-cpu=native                                   |
| SASSY_RUST_FEATURES | native-simd                                            |
| RETICULATE_PYTHON   | /root/sassy/.venv-benchmark/bin/python                 |
| cargo               | cargo 1.91.1 (ea2d97820 2025-10-10)                    |
| rustc               | rustc 1.91.1 (ed61e7d7e 2025-11-07)                    |
| python              | Python 3.11.14                                         |
| simd_flags          | sse sse2 fma sse4_1 sse4_2 avx bmi1 avx2 bmi2 avx_vnni |

## Input data

| batches | iterations_per_batch | warmup | text_length | pattern_length |   k | inserted_matches | insertion_spacing |
|--------:|---------------------:|-------:|------------:|---------------:|----:|-----------------:|------------------:|
|       7 |                 1000 |      2 |       1e+06 |             42 |   2 |               10 |             1e+05 |

## Benchmarked calls

| binding                     | batches | iterations_per_batch | text_length | pattern_length |   k | matches | min_seconds | median_seconds | mean_seconds | p95_seconds | max_seconds | calls_per_second |
|:----------------------------|--------:|---------------------:|------------:|---------------:|----:|--------:|------------:|---------------:|-------------:|------------:|------------:|-----------------:|
| Rsassy reusable raw         |       7 |                 1000 |       1e+06 |             42 |   2 |      10 |    0.000267 |       0.000269 |    0.0002686 |   0.0002704 |    0.000271 |         3717.472 |
| Rsassy reusable character   |       7 |                 1000 |       1e+06 |             42 |   2 |      10 |    0.000273 |       0.000273 |    0.0002736 |   0.0002754 |    0.000276 |         3663.004 |
| Rsassy one-shot raw         |       7 |                 1000 |       1e+06 |             42 |   2 |      10 |    0.000277 |       0.000278 |    0.0002784 |   0.0002804 |    0.000281 |         3597.122 |
| sassyRS one-shot raw        |       7 |                 1000 |       1e+06 |             42 |   2 |      10 |    0.000409 |       0.000409 |    0.0004107 |   0.0004154 |    0.000416 |         2444.988 |
| Python sassy via reticulate |       7 |                 1000 |       1e+06 |             42 |   2 |      10 |    0.000488 |       0.000490 |    0.0004901 |   0.0004930 |    0.000493 |         2040.816 |

## Summary

| binding                     | median_seconds | calls_per_second | matches |
|:----------------------------|---------------:|-----------------:|--------:|
| Rsassy reusable raw         |       0.000269 |         3717.472 |      10 |
| Rsassy reusable character   |       0.000273 |         3663.004 |      10 |
| Rsassy one-shot raw         |       0.000278 |         3597.122 |      10 |
| sassyRS one-shot raw        |       0.000409 |         2444.988 |      10 |
| Python sassy via reticulate |       0.000490 |         2040.816 |      10 |

    #> Wrote benchmark results to /root/sassy/r/benchmarks/results/r-bindings.csv
