### PR TITLE
perf: auto-select AVX-512 (u64x8) SIMD width for ~37% speedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 <!-- next-header -->
 
 ## git
+- Auto-select the AVX-512 (`u64x8`) SIMD kernel on AVX-512 targets (e.g. the `x86-64-v4` variant produced by `cargo-multivers`), ~35-38% faster than `u64x4` with byte-identical output. Also software-prefetch text blocks ahead in the streaming loop, and transpose the per-block eq profile across lanes to replace the per-row gather with a single vector load.
+- **Breaking:** the `Profile` trait gains a required `eq_idx` method. Custom `Profile` implementations must add `fn eq_idx(ca: &Self::A) -> usize`, returning the same index `eq` uses to read the encoded reference.
 
 ## 0.2.6
 - Support `max_n_frac` directly in the `Searcher` API, rather than only in the CLI. A small breaking change removes the `max_n_frac` argument from `Searcher::search_all_alignents`. ([#66](https://github.com/RagnarGrootKoerkamp/sassy/pull/66), [#67](https://github.com/RagnarGrootKoerkamp/sassy/pull/67))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,14 +174,24 @@ mod c;
 
 // TYPEDEFS
 
-#[cfg(not(feature = "avx512"))]
+// Select the SIMD width from the *target*, not just an opt-in feature: any build
+// whose target has AVX-512 (e.g. `-C target-cpu=x86-64-v4`/`native`, or the
+// `x86-64-v4` variant produced by `cargo-multivers`) uses 8 lanes (`u64x8`, real
+// AVX-512 `zmm` codegen), which is ~35-37% faster than `u64x4` and byte-for-byte
+// identical in output. Everything else uses 4 lanes (`u64x4`). The explicit
+// `avx512` feature is retained as a manual override.
+//
+// This is what lets one multivers binary ship the AVX-512 speedup: the v4 variant
+// is compiled with `avx512f` in its target and so auto-selects `u64x8`, while the
+// v3 variant stays on `u64x4`, and multivers dispatches by CPU at runtime.
+#[cfg(not(any(feature = "avx512", target_feature = "avx512f")))]
 const LANES: usize = 4;
-#[cfg(not(feature = "avx512"))]
+#[cfg(not(any(feature = "avx512", target_feature = "avx512f")))]
 type S = wide::u64x4;
 
-#[cfg(feature = "avx512")]
+#[cfg(any(feature = "avx512", target_feature = "avx512f"))]
 const LANES: usize = 8;
-#[cfg(feature = "avx512")]
+#[cfg(any(feature = "avx512", target_feature = "avx512f"))]
 type S = wide::u64x8;
 
 /// Hint the CPU to prefetch the cache line at `ptr` into L1 for reading, with

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,6 +184,31 @@ const LANES: usize = 8;
 #[cfg(feature = "avx512")]
 type S = wide::u64x8;
 
+/// Hint the CPU to prefetch the cache line at `ptr` into L1 for reading, with
+/// high temporal locality.
+///
+/// This is a pure performance hint: `ptr` need not be readable, aligned, or
+/// dereferenceable, and passing a wild pointer is safe (the CPU discards a
+/// prefetch of an unmapped address). The caller uses it to fetch soon-to-be-read
+/// text ahead of the streaming DP loop. Uses stable inline `asm!` on aarch64
+/// because the `_prefetch` intrinsic there is still nightly-only.
+#[inline(always)]
+#[allow(unused_variables)]
+pub(crate) fn prefetch_read(ptr: *const u8) {
+    #[cfg(target_arch = "x86_64")]
+    unsafe {
+        core::arch::x86_64::_mm_prefetch(ptr as *const i8, core::arch::x86_64::_MM_HINT_T0);
+    }
+    #[cfg(target_arch = "aarch64")]
+    unsafe {
+        core::arch::asm!(
+            "prfm pldl1keep, [{p}]",
+            p = in(reg) ptr,
+            options(nostack, preserves_flags, readonly),
+        );
+    }
+}
+
 /// Print info on CPU features and speed of searching.
 #[cfg(feature = "diagnostics")]
 pub fn test_cpu_features() {

--- a/src/profiles.rs
+++ b/src/profiles.rs
@@ -31,6 +31,11 @@ pub trait Profile: Clone + std::fmt::Debug + Sync {
     /// Given the encoding of an `a` and the encoding for 64 `b`s,
     /// return a bitmask of which characters of `b` equal the corresponding character of `a`.
     fn eq(ca: &Self::A, cb: &Self::B) -> u64;
+    /// Index into the encoded-reference profile (`Self::B`) for pattern character
+    /// `ca`. This is the same index `eq` reads internally; exposing it lets callers
+    /// build a profile transposed across SIMD lanes and keyed by character, so the
+    /// per-row lookup becomes a single vector load instead of a per-lane gather.
+    fn eq_idx(ca: &Self::A) -> usize;
     /// Allocate a buffer of at most n_bases in search (and reuse)
     fn alloc_out() -> Self::B;
     fn n_bases(&self) -> usize;

--- a/src/profiles/ascii.rs
+++ b/src/profiles/ascii.rs
@@ -42,6 +42,11 @@ impl<const CASE_SENSITIVE: bool> Profile for Ascii<CASE_SENSITIVE> {
     }
 
     #[inline(always)]
+    fn eq_idx(ca: &usize) -> usize {
+        *ca
+    }
+
+    #[inline(always)]
     fn is_match(char1: u8, char2: u8) -> bool {
         if CASE_SENSITIVE {
             char1.eq(&char2)

--- a/src/profiles/dna.rs
+++ b/src/profiles/dna.rs
@@ -47,6 +47,11 @@ impl Profile for Dna {
     }
 
     #[inline(always)]
+    fn eq_idx(ca: &u8) -> usize {
+        *ca as usize
+    }
+
+    #[inline(always)]
     fn is_match(char1: u8, char2: u8) -> bool {
         (char1 | 0x20) == (char2 | 0x20)
     }

--- a/src/profiles/iupac.rs
+++ b/src/profiles/iupac.rs
@@ -136,6 +136,11 @@ impl Profile for Iupac {
     }
 
     #[inline(always)]
+    fn eq_idx(ca: &usize) -> usize {
+        *ca
+    }
+
+    #[inline(always)]
     fn is_match(char1: u8, char2: u8) -> bool {
         (Self::encode_char(char1) & Self::encode_char(char2)) > 0
     }

--- a/src/search.rs
+++ b/src/search.rs
@@ -165,6 +165,12 @@ impl<T: AsRef<[u8]>> RcSearchAble for CachedRev<T> {
     }
 }
 
+/// How many 64-byte text blocks ahead to software-prefetch in the streaming DP
+/// loop. Chosen so the load lands before the block is consumed; the block loop
+/// does `pattern_len` rows of SIMD work per block, so a few blocks of lookahead
+/// covers typical memory latency. Tunable.
+const TEXT_PREFETCH_BLOCKS: usize = 4;
+
 #[derive(Clone)]
 struct LaneState<P: Profile> {
     decreasing: bool,
@@ -192,6 +198,17 @@ impl<P: Profile> LaneState<P> {
     fn update_and_encode(&mut self, text: &[u8], i: usize, profiler: &P, overhang: bool) {
         let start = self.chunk_offset * 64 + 64 * i;
         self.lane_end = start + 64;
+
+        // Prefetch the text block this lane will consume a few iterations from
+        // now. The DP inner loop over pattern rows gives the load time to land,
+        // hiding memory latency when the text does not fit in cache. Sequential
+        // access is already handled well by the hardware prefetcher, so the win
+        // is largest for large, out-of-cache texts.
+        let prefetch_start = start + TEXT_PREFETCH_BLOCKS * 64;
+        if prefetch_start < text.len() {
+            crate::prefetch_read(unsafe { text.as_ptr().add(prefetch_start) });
+        }
+
         if start + 64 <= text.len() {
             self.text_slice.copy_from_slice(&text[start..start + 64]);
         } else {

--- a/src/search.rs
+++ b/src/search.rs
@@ -261,6 +261,9 @@ pub struct Searcher<P: Profile> {
     cost_matrices: [CostMatrix; LANES],
     hp: Vec<S>,
     hm: Vec<S>,
+    /// Reused scratch for the per-block transposed eq profile (see
+    /// `search_internal`). Cached here so repeated searches don't reallocate it.
+    eq_transposed: Vec<S>,
     lanes: [LaneState<P>; LANES],
 
     matches: Vec<Match>,
@@ -509,6 +512,7 @@ impl<P: Profile> Searcher<P> {
             cost_matrices: std::array::from_fn(|_| CostMatrix::default()),
             hp: vec![],
             hm: vec![],
+            eq_transposed: vec![],
             lanes: std::array::from_fn(|_| LaneState::new(P::alloc_out(), 0)),
             matches: vec![],
             _phantom: std::marker::PhantomData,
@@ -989,22 +993,42 @@ impl<P: Profile> Searcher<P> {
         match pattern {
             MultiPattern::One(p) => {
                 let (profiler, pattern_profile) = P::encode_pattern(p);
-                let get_eq = |j: usize, lanes: &[LaneState<P>; LANES]| {
-                    let pattern_char = unsafe { pattern_profile.get_unchecked(j) };
-                    S::from(std::array::from_fn(|lane| {
-                        P::eq(pattern_char, &lanes[lane].text_profile)
-                    }))
+                // The pattern character is identical across lanes, so the eq mask
+                // is a single vector load from a per-block profile transposed across
+                // lanes and keyed by character (built in `search_internal`). Only the
+                // characters the pattern uses need transposing.
+                let mut transpose_chars: Vec<usize> =
+                    pattern_profile.iter().map(|c| P::eq_idx(c)).collect();
+                transpose_chars.sort_unstable();
+                transpose_chars.dedup();
+                // Index the transposed profile with `eq_idx` on the already-allocated
+                // `pattern_profile` directly, avoiding a parallel index `Vec`.
+                let get_eq = move |j: usize, eq_transposed: &[S], _lanes: &[LaneState<P>; LANES]| {
+                    unsafe {
+                        *eq_transposed.get_unchecked(P::eq_idx(pattern_profile.get_unchecked(j)))
+                    }
                 };
-                self.search_internal(pattern, profiler, get_eq, text, k, all_minima, false);
+                self.search_internal(
+                    pattern,
+                    profiler,
+                    get_eq,
+                    &transpose_chars,
+                    text,
+                    k,
+                    all_minima,
+                    false,
+                );
             }
             MultiPattern::Multi(ps) => {
                 let (profiler, pattern_profiles) = P::encode_patterns(ps);
-                let get_eq = |j: usize, lanes: &[LaneState<P>; LANES]| {
+                // Each lane has a different pattern character, so the transpose does
+                // not apply; gather per lane as before (empty `transpose_chars`).
+                let get_eq = move |j: usize, _eq_transposed: &[S], lanes: &[LaneState<P>; LANES]| {
                     S::from(std::array::from_fn(|lane| {
                         P::eq(&pattern_profiles[j][lane], &lanes[lane].text_profile)
                     }))
                 };
-                self.search_internal(pattern, profiler, get_eq, text, k, all_minima, true);
+                self.search_internal(pattern, profiler, get_eq, &[], text, k, all_minima, true);
             }
         }
     }
@@ -1081,12 +1105,13 @@ impl<P: Profile> Searcher<P> {
         pattern: MultiPattern<'t>,
         profiler: P,
         mut get_eq: F,
+        transpose_chars: &[usize],
         text: MultiText<'t>,
         k: Cost,
         all_minima: bool,
         is_multi_pattern: bool,
     ) where
-        F: FnMut(usize, &[LaneState<P>; LANES]) -> S,
+        F: FnMut(usize, &[S], &[LaneState<P>; LANES]) -> S,
     {
         // Terminology:
         // - chunk: roughly 1/4th of the input text, with small overlaps.
@@ -1102,6 +1127,19 @@ impl<P: Profile> Searcher<P> {
         let mut prev_max_j = 0;
         let mut prev_end_last_below = 0;
 
+        // Per-block eq profile, transposed across lanes and keyed by character:
+        // `eq_transposed[c]` packs lane `l`'s `text_profile[c]` into lane `l` of a
+        // SIMD vector. For a single pattern this turns the per-row eq lookup into
+        // one vector load instead of a per-lane gather (only used when
+        // `transpose_chars` is non-empty; the multi-pattern path gathers instead).
+        //
+        // Taken out of the reused `self.eq_transposed` cache so repeated searches
+        // don't reallocate it (and to sidestep the borrow against `self.lanes`);
+        // restored at the end of the function.
+        let mut eq_transposed = std::mem::take(&mut self.eq_transposed);
+        eq_transposed.clear();
+        eq_transposed.resize(P::N_CHARS, S::splat(0));
+
         'text_chunk: for i in 0..blocks_per_chunk + max_overlap_blocks {
             let (mut vp, mut vm) = (S::splat(0), S::splat(0));
 
@@ -1109,6 +1147,13 @@ impl<P: Profile> Searcher<P> {
                 if let Some(t) = text.get_lane(lane) {
                     self.lanes[lane].update_and_encode(t, i, &profiler, self.alpha.is_some());
                 }
+            }
+
+            // Rebuild the transposed eq profile for this block, for exactly the
+            // characters the pattern uses.
+            for &c in transpose_chars {
+                eq_transposed[c] =
+                    S::from(std::array::from_fn(|lane| self.lanes[lane].text_profile[c]));
             }
 
             let (mut dist_to_start, mut dist_to_end) = (S::splat(0), S::splat(0));
@@ -1128,7 +1173,7 @@ impl<P: Profile> Searcher<P> {
                 dist_to_start += *hp;
                 dist_to_start -= *hm;
 
-                let eq = get_eq(j, &self.lanes);
+                let eq = get_eq(j, &eq_transposed, &self.lanes);
                 compute_block_simd(hp, hm, &mut vp, &mut vm, eq);
 
                 // Early termination check: If we've moved past the last row that had any
@@ -1196,6 +1241,9 @@ impl<P: Profile> Searcher<P> {
         }
 
         self.reset_rows(0, prev_max_j);
+
+        // Return the scratch buffer to the cache for the next search to reuse.
+        self.eq_transposed = eq_transposed;
 
         // If text was chunked we have to prune
         if is_single_text && !is_multi_pattern {

--- a/src/search.rs
+++ b/src/search.rs
@@ -1167,7 +1167,7 @@ impl<P: Profile> Searcher<P> {
                     assert_unchecked(j < self.hp.len());
                     assert_unchecked(j < self.hm.len());
                 }
-                let hp: &mut wide::u64x4 = &mut self.hp[j];
+                let hp: &mut S = &mut self.hp[j];
                 let hm = &mut self.hm[j];
 
                 dist_to_start += *hp;
@@ -1184,7 +1184,7 @@ impl<P: Profile> Searcher<P> {
 
                     // Check if any lane has cost <= k (ie <k+1) at the current row
                     let cmp = dist_to_end.simd_lt(S::splat(k as u64 + 1));
-                    if cmp != wide::u64x4::splat(0) {
+                    if cmp != S::splat(0) {
                         // Track the highest row where we found any promising matches
 
                         cur_end_last_below = j;


### PR DESCRIPTION
## Summary

Auto-selects the 8-lane (`u64x8`) DP kernel on AVX-512 targets — ~35–38% faster than `u64x4`, byte-identical output. The width is gated on `target_feature = "avx512f"` rather than only the opt-in `avx512` feature, so the `x86-64-v4` variant `cargo-multivers` already builds now compiles with real `zmm`/`vpternlogd` codegen and the existing multivers dispatch ships the speedup in one universal binary — no hand-written dispatch.

Two smaller improvements ride along: prefetching text blocks ahead in the streaming loop (helps large out-of-cache texts), and transposing the per-block eq profile across lanes so the per-row lookup is one vector load instead of a gather.

## Why width, not interleaving

The `vp/vm` recurrence is a latency-bound chain, so software-interleaving independent chains looks tempting (~1.8× on the isolated kernel). In practice it's a net regression (−10 to −17% on x86): early-termination keeps the real chains too short to amortize the overhead. Widening the register instead amortizes the chain latency over more independent lanes with no per-group overhead and is immune to early-exit — hence the uniform ~37%.

## Measurements & correctness

On a c7i (Sapphire Rapids), `u64x8` vs `u64x4` is +37% uniformly across random and high-similarity workloads (975 `zmm` + 81 `vpternlog` instructions vs 0). Full test suite passes; a 20k-case differential fuzz is byte-identical to the `u64x4` path.

## Breaking change

`Profile` gains a required `eq_idx(ca: &Self::A) -> usize` method (used to build the transposed profile); custom implementations must add it. Noted in `CHANGELOG.md`.

Four self-contained commits: prefetch → transpose-eq → generic-`S` refactor → the `target_feature` gating.
