### PR TITLE
refactor: drop hand-rolled u8x32_gt in favor of wide's native compare

### DIFF
--- a/src/profiles.rs
+++ b/src/profiles.rs
@@ -63,20 +63,7 @@ pub trait Profile: Clone + std::fmt::Debug + Sync {
     }
 }
 
-// Simd helpers for stuff missing from wide.
-// FIXME: Upstream into `wide`.
-#[inline(always)]
-fn u8x32_gt(a: u8x32, b: u8x32) -> u8x32 {
-    unsafe {
-        use std::mem::transmute;
-        use wide::i8x32;
-        let a: i8x32 = transmute(a);
-        let b: i8x32 = transmute(b);
-        let mask = i8x32::splat(1 << 7);
-        transmute(wide::CmpGt::simd_gt(a ^ mask, b ^ mask))
-    }
-}
-
+// Simd helper for stuff missing from wide.
 // FIXME: Upstream into `wide`.
 #[inline(always)]
 fn u8x32_shr(a: u8x32, shift: u8) -> u8x32 {

--- a/src/profiles/ascii.rs
+++ b/src/profiles/ascii.rs
@@ -1,5 +1,5 @@
-use crate::profiles::{Profile, u8x32_gt};
-use wide::{CmpEq, u8x32};
+use crate::profiles::Profile;
+use wide::{CmpEq, CmpGt, u8x32};
 
 /// Compare two sequences using the stancard ASCII alphabet.
 #[derive(Clone, Debug)]
@@ -102,9 +102,9 @@ fn ascii_u64_search_case_insensitive(seq: &[u8; 64], bases: &[u8], out: &mut [u6
         // AVX2 does not have unsigned u8 compares for b'A' <= x <= b'Z'.
         // Instead, we check `(x-b'A') <= b'Z'-b'A'
         let is_char0 =
-            u8x32_gt(chunk0, u8x32::splat(A - 1)) & u8x32_gt(u8x32::splat(Z + 1), chunk0);
+            chunk0.simd_gt(u8x32::splat(A - 1)) & u8x32::splat(Z + 1).simd_gt(chunk0);
         let is_char1 =
-            u8x32_gt(chunk1, u8x32::splat(A - 1)) & u8x32_gt(u8x32::splat(Z + 1), chunk1);
+            chunk1.simd_gt(u8x32::splat(A - 1)) & u8x32::splat(Z + 1).simd_gt(chunk1);
         // Transmute from i8x32 to u8x32
         let lower0 = chunk0 | (u8x32::splat(to_lowercase) & is_char0);
         let lower1 = chunk1 | (u8x32::splat(to_lowercase) & is_char1);

--- a/src/profiles/iupac.rs
+++ b/src/profiles/iupac.rs
@@ -1,9 +1,9 @@
 use crate::{
     LANES,
-    profiles::{Profile, u8x32_gt, u8x32_shr},
+    profiles::{Profile, u8x32_shr},
 };
 use std::mem::transmute;
-use wide::{CmpEq, u8x32};
+use wide::{CmpEq, CmpGt, u8x32};
 
 /// IUPAC alphabet: ACGT + NYR...
 ///
@@ -84,8 +84,8 @@ impl Profile for Iupac {
             let idx5_0 = chunk0 & mask5;
             let idx5_1 = chunk1 & mask5;
 
-            let is_hi_0 = u8x32_gt(idx5_0, u8x32::splat(15));
-            let is_hi_1 = u8x32_gt(idx5_1, u8x32::splat(15));
+            let is_hi_0 = idx5_0.simd_gt(u8x32::splat(15));
+            let is_hi_1 = idx5_1.simd_gt(u8x32::splat(15));
 
             let tbl256 = u8x32::from(transmute::<_, [u8; 32]>([PACKED_NIBBLES, PACKED_NIBBLES]));
 
@@ -173,14 +173,14 @@ impl Profile for Iupac {
 
                 // Check if > '@' (64) (=b'A'-1) and < 128.
                 let in_range =
-                    u8x32_gt(upper, u8x32::splat(64)) & u8x32_gt(u8x32::splat(128), upper);
+                    upper.simd_gt(u8x32::splat(64)) & u8x32::splat(128).simd_gt(upper);
                 if !in_range.all() {
                     return false;
                 }
 
                 let idx5 = upper & u8x32::splat(0x1F);
                 let low4 = idx5 & mask4;
-                let is_hi = u8x32_gt(idx5, u8x32::splat(15));
+                let is_hi = idx5.simd_gt(u8x32::splat(15));
                 let shuffled = half_shuffle(tbl256, low4);
                 let lo_nib = shuffled & mask4;
                 let hi_nib = shuffled & high4;


### PR DESCRIPTION
Cleanup, not a perf change. `wide` already provides an unsigned `u8x32` comparison, so the hand-rolled `u8x32_gt` helper — which transmuted to `i8x32` and did a manual sign-flip — is redundant. This replaces its call sites with `.simd_gt()` and deletes the helper (−12 lines of `unsafe` transmute, and one fewer "FIXME: upstream into wide").

- Output is unchanged: a differential fuzz (20k random cases, Dna + Iupac, fwd + rc, `search` + `search_all`) is byte-identical before and after, and the full test suite passes.
- No new clippy warnings.
- Incidentally uses `wide`'s native `vcgtq_u8` on NEON instead of the sign-flip, which shaves a few percent off the `encode_ref` microbench — but that's marginal end-to-end and not the point of the change.

The sibling `u8x32_shr` helper is intentionally left in place: dropping it needs `wide` 1.5 (which adds `u8x32 Shr`), and that release deprecates the `Cmp*` traits that `pattern_tiling/backend.rs` uses structurally, so that bump belongs in its own change.
