### PR TITLE
fix: two platform-independent correctness bugs in the WGPU search path

### DIFF
--- a/src/pattern_tiling/search.rs
+++ b/src/pattern_tiling/search.rs
@@ -118,6 +118,14 @@ impl<B: SimdBackend, P: Profile> Myers<B, P> {
         }
 
         // eprintln!("length_mask: {} {}", self.active_ranges.len(), n_queries);
+        // The WGPU trace path reaches search_prep without going through
+        // `search_ranges` (range finding runs on the GPU), so the per-query
+        // `active_ranges` buffer may not yet be sized to `n_queries`. The CPU
+        // path always resizes it beforehand; do the same defensively here so
+        // the fill below cannot index out of bounds.
+        if self.active_ranges.len() < n_queries {
+            self.active_ranges.resize(n_queries, isize::MIN);
+        }
         self.active_ranges[..n_queries].fill(isize::MIN);
         self.hit_ranges.clear();
     }

--- a/src/pattern_tiling/search_wgpu.rs
+++ b/src/pattern_tiling/search_wgpu.rs
@@ -276,19 +276,8 @@ impl MyersWgpu {
 
         let peqs = precompute_peqs::<P>(queries);
 
-        let max_hits = (num_patterns as usize * 10).max(1);
-
-        let params = MyersParams {
-            text_len: text.len() as u32,
-            pattern_length,
-            num_patterns,
-            k,
-            alpha_pattern,
-            last_bit_shift: pattern_length.saturating_sub(1),
-            max_hits: max_hits as u32,
-        };
-
-        // Create buffers.
+        // Text and PEQ buffers are independent of max_hits, so build them once
+        // and reuse them across the grow-and-retry dispatches below.
         let text_buffer = self
             .device
             .create_buffer_init(&wgpu::util::BufferInitDescriptor {
@@ -305,7 +294,81 @@ impl MyersWgpu {
                 usage: wgpu::BufferUsages::STORAGE,
             });
 
-        let hit_ranges_size = (max_hits * std::mem::size_of::<GpuHitRange>()) as u64;
+        let num_workgroups = num_patterns.div_ceil(gpu_kernel::WORKGROUP_SIZE);
+
+        // The kernel counts every hit atomically but only writes ranges while
+        // idx < max_hits. If the true count exceeds the buffer, the surplus is
+        // dropped, so grow to the reported count and re-dispatch until every hit
+        // fits (converges in <= 2 iterations: the retry sizes to the exact count).
+        let mut max_hits = (num_patterns as usize * 10).max(1);
+        let (hit_count, hit_ranges_staging) = loop {
+            let params = MyersParams {
+                text_len: text.len() as u32,
+                pattern_length,
+                num_patterns,
+                k,
+                alpha_pattern,
+                last_bit_shift: pattern_length.saturating_sub(1),
+                max_hits: max_hits as u32,
+            };
+            let (hit_count, hit_ranges_staging) = self
+                .dispatch_and_count(&params, &text_buffer, &peqs_buffer, num_workgroups)
+                .await?;
+            match next_hit_capacity(hit_count, max_hits as u32) {
+                Some(bigger) => max_hits = bigger as usize, // overflow: grow and retry
+                None => break (hit_count, hit_ranges_staging),
+            }
+        };
+
+        let actual_hits = (hit_count as usize).min(max_hits);
+        if actual_hits == 0 {
+            return Ok(Vec::new());
+        }
+
+        // Read back hit ranges.
+        let ranges_slice = hit_ranges_staging.slice(..);
+        let (ranges_sender, ranges_receiver) = futures::channel::oneshot::channel();
+        ranges_slice.map_async(wgpu::MapMode::Read, move |result| {
+            let _ = ranges_sender.send(result);
+        });
+        let _ = self.device.poll(wgpu::PollType::Wait);
+        ranges_receiver
+            .await
+            .map_err(|e| WgpuSearchError::Other(format!("Channel error: {e:?}")))?
+            .map_err(|e| WgpuSearchError::Other(format!("Buffer async error: {e:?}")))?;
+
+        let hit_ranges = {
+            let view = ranges_slice.get_mapped_range();
+            let gpu_ranges: &[GpuHitRange] = bytemuck::cast_slice(&view);
+            gpu_ranges[..actual_hits]
+                .iter()
+                .map(|r| HitRange {
+                    pattern_idx: r.pattern_idx as usize,
+                    start: r.start as isize,
+                    end: r.end as isize,
+                })
+                .collect()
+        };
+        hit_ranges_staging.unmap();
+
+        Ok(hit_ranges)
+    }
+
+    /// Dispatch the kernel once with `params` and read back the atomic hit count.
+    /// Returns the count and the hit-ranges staging buffer (mapped-readable), so
+    /// the caller can read ranges from the final, non-overflowing dispatch. Fresh
+    /// hit-ranges/hit-count buffers are created each call (their size depends on
+    /// `params.max_hits`); the `text`/`peqs` buffers are passed in and reused.
+    async fn dispatch_and_count(
+        &self,
+        params: &MyersParams,
+        text_buffer: &wgpu::Buffer,
+        peqs_buffer: &wgpu::Buffer,
+        num_workgroups: u32,
+    ) -> Result<(u32, wgpu::Buffer), WgpuSearchError> {
+        let hit_ranges_size =
+            (params.max_hits as usize * std::mem::size_of::<GpuHitRange>()) as u64;
+
         let hit_ranges_buffer = self.device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("Myers Hit Ranges Buffer"),
             size: hit_ranges_size,
@@ -358,8 +421,6 @@ impl MyersWgpu {
             ],
         });
 
-        let num_workgroups = num_patterns.div_ceil(gpu_kernel::WORKGROUP_SIZE);
-
         let mut encoder = self
             .device
             .create_command_encoder(&wgpu::CommandEncoderDescriptor {
@@ -373,17 +434,11 @@ impl MyersWgpu {
             });
             compute_pass.set_pipeline(&self.pipeline);
             compute_pass.set_bind_group(0, &bind_group, &[]);
-            compute_pass.set_push_constants(0, bytemuck::bytes_of(&params));
+            compute_pass.set_push_constants(0, bytemuck::bytes_of(params));
             compute_pass.dispatch_workgroups(num_workgroups.max(1), 1, 1);
         }
 
-        encoder.copy_buffer_to_buffer(
-            &hit_ranges_buffer,
-            0,
-            &hit_ranges_staging,
-            0,
-            hit_ranges_size,
-        );
+        encoder.copy_buffer_to_buffer(&hit_ranges_buffer, 0, &hit_ranges_staging, 0, hit_ranges_size);
         encoder.copy_buffer_to_buffer(
             &hit_count_buffer,
             0,
@@ -409,43 +464,24 @@ impl MyersWgpu {
 
         let hit_count = {
             let view = count_slice.get_mapped_range();
-            let count: u32 = bytemuck::cast_slice::<u8, u32>(&view)[0];
-            count
+            bytemuck::cast_slice::<u8, u32>(&view)[0]
         };
         hit_count_staging.unmap();
 
-        let actual_hits = (hit_count as usize).min(max_hits);
-        if actual_hits == 0 {
-            return Ok(Vec::new());
-        }
+        Ok((hit_count, hit_ranges_staging))
+    }
+}
 
-        // Read back hit ranges.
-        let ranges_slice = hit_ranges_staging.slice(..);
-        let (ranges_sender, ranges_receiver) = futures::channel::oneshot::channel();
-        ranges_slice.map_async(wgpu::MapMode::Read, move |result| {
-            let _ = ranges_sender.send(result);
-        });
-        let _ = self.device.poll(wgpu::PollType::Wait);
-        ranges_receiver
-            .await
-            .map_err(|e| WgpuSearchError::Other(format!("Channel error: {e:?}")))?
-            .map_err(|e| WgpuSearchError::Other(format!("Buffer async error: {e:?}")))?;
-
-        let hit_ranges = {
-            let view = ranges_slice.get_mapped_range();
-            let gpu_ranges: &[GpuHitRange] = bytemuck::cast_slice(&view);
-            gpu_ranges[..actual_hits]
-                .iter()
-                .map(|r| HitRange {
-                    pattern_idx: r.pattern_idx as usize,
-                    start: r.start as isize,
-                    end: r.end as isize,
-                })
-                .collect()
-        };
-        hit_ranges_staging.unmap();
-
-        Ok(hit_ranges)
+/// Given the atomically-counted hit total reported by the kernel and the
+/// capacity of the output buffer it wrote into, return `Some(new_capacity)` if
+/// the buffer overflowed (so the caller must re-dispatch with a bigger buffer),
+/// or `None` if all hits fit. The kernel counts every hit but only writes while
+/// `idx < max_hits`, so `reported > capacity` means hits were dropped.
+fn next_hit_capacity(reported: u32, current_capacity: u32) -> Option<u32> {
+    if reported > current_capacity {
+        Some(reported)
+    } else {
+        None
     }
 }
 
@@ -505,6 +541,18 @@ fn generate_alpha_mask(alpha: f32, length: usize) -> u64 {
     }
 
     mask
+}
+
+#[cfg(test)]
+mod max_hits_tests {
+    use super::next_hit_capacity;
+
+    #[test]
+    fn detects_overflow_and_requests_true_count() {
+        assert_eq!(next_hit_capacity(5, 10), None); // fits: no retry
+        assert_eq!(next_hit_capacity(10, 10), None); // exactly full: no drop
+        assert_eq!(next_hit_capacity(23, 10), Some(23)); // overflow: grow to 23
+    }
 }
 
 #[cfg(test)]

--- a/src/pattern_tiling/search_wgpu.rs
+++ b/src/pattern_tiling/search_wgpu.rs
@@ -515,7 +515,7 @@ mod tests {
     #[test]
     #[ignore] // Only run when a WGPU-compatible GPU/driver is available.
     fn test_wgpu_search_basic() {
-        let searcher = pollster::block_on(MyersWgpu::new()).expect("Failed to initialize WGPU");
+        let searcher = MyersWgpu::new();
 
         let queries = vec![b"ACGT".to_vec(), b"TGCA".to_vec()];
         let text = b"AAACGTTTGCAAA";

--- a/src/pattern_tiling/trace.rs
+++ b/src/pattern_tiling/trace.rs
@@ -287,9 +287,14 @@ pub fn trace_batch_ranges<B: SimdBackend, P: Profile>(
 
     // Prep allocs for single block search
     let length_mask = (!0u64) >> (64usize.saturating_sub(t_queries.pattern_length));
+    // Only the current trace batch (<= LANES) is active here, so size the
+    // per-query state to `filled_till`, consistent with `history`/`positions`
+    // (sized by `ensure_capacity(1, buffer.filled_till)` above). The GPU search
+    // path reaches this without `Myers::search_ranges` having grown the buffers
+    // to `n_queries`, so passing `n_queries` here would overrun `active_ranges`.
     searcher.search_prep(
         1,
-        t_queries.n_queries,
+        buffer.filled_till,
         t_queries.pattern_length,
         searcher.alpha_pattern & length_mask,
     );
@@ -449,4 +454,34 @@ fn traceback_single<B: SimdBackend, P: Profile>(
     };
 
     m
+}
+
+#[cfg(test)]
+mod trace_gpu_path_tests {
+    use super::*;
+    use crate::pattern_tiling::backend::U32Backend;
+    use crate::pattern_tiling::search::{HitRange, Myers};
+    use crate::pattern_tiling::tqueries::TQueries;
+    use crate::profiles::Iupac;
+
+    // Reproduces the GPU trace path: a fresh Myers (per-query buffers never grown
+    // by search_ranges) traced against RC-doubled queries whose n_queries far
+    // exceeds a single block. Must not panic / index out of bounds.
+    #[test]
+    fn trace_batch_ranges_tolerates_ungrown_active_ranges() {
+        let mut searcher = Myers::<U32Backend, Iupac>::new(None);
+        let queries = vec![b"ACGTACGTACGTACGTACGT".to_vec()]; // 1 pattern, 20bp
+        let tq = TQueries::<U32Backend, Iupac>::new(&queries, /*include_rc=*/ true);
+        assert!(tq.n_queries >= 2, "RC should give n_queries >= 2");
+
+        let text = b"ACGTACGTACGTACGTACGTACGT";
+        let ranges = [HitRange { pattern_idx: 0, start: 0, end: 19 }];
+        let mut buffer = TraceBuffer::new(U32Backend::LANES);
+
+        // Pre-fix: panics "range end index {n_queries} out of range for slice of length {LANES-ish}".
+        trace_batch_ranges::<U32Backend, Iupac>(
+            &mut searcher, &tq, text, &ranges, 3,
+            TracePostProcess::LocalMinima, None, None, &mut buffer,
+        );
+    }
 }


### PR DESCRIPTION
Two bugs in the WGPU GPU search path, both independent of platform (they bite on Linux/NVIDIA too). These look like the "differences with the SIMD backends" / "only works with 1 pattern" behaviour noted on the branch.

## 1. Trace-buffer overrun with >1 pattern

`fix: size active_ranges to the trace batch on the GPU search path`

The GPU path finds candidate ranges on the GPU and skips `Myers::search_ranges`, where the CPU path grows the per-query `active_ranges` buffer to `n_queries`. `trace_batch_ranges` then called `search_prep` with `n_queries` (doubled when reverse-complement search is on), overrunning the single-block-sized buffer and panicking (`range end index N out of range for slice of length …`). Fixed by passing `buffer.filled_till` (≤ `LANES`) at the call site — consistent with how `history`/`positions` are already sized — plus a defensive resize guard in `search_prep`. Adds a headless regression test that reproduces the overrun without a GPU.

## 2. Silent hit-drop on dense inputs

`fix: grow-and-retry GPU hit buffer instead of silently dropping hits`

Output was capped at `max_hits = num_patterns * 10`. The kernel counts every hit atomically but only writes ranges while `idx < max_hits`, and the host kept `min(hit_count, max_hits)` — so once candidates exceed the cap, surplus ranges are dropped nondeterministically (atomic slot race) and the GPU under-reports vs. the CPU backends, with no error. This is invisible on sparse inputs and near-certain on the large/dense workloads the branch targets. Now detects overflow via the reported count and re-dispatches with a buffer sized to it (converges in ≤ 2 passes). The per-dispatch work is extracted into `dispatch_and_count`.

Verified end-to-end on-GPU by forcing `max_hits = 1`: grow-retry recovers every hit (GPU count == CPU `v2` count on the `modes` example workload).

## Also

Folds in a one-line fix for a pre-existing ignored wgpu test that didn't compile (`pollster::block_on` wrapping the non-async `MyersWgpu::new()`), which had been blocking the `-F wgpu` test target.

## Testing

Deterministic lib suite passes (113/113). The `fuzz_against_sassy_*` fuzzers pass unchanged. GPU paths validated locally on Apple Silicon via MoltenVK (macOS build support is a separate follow-up PR).
