### PR TITLE
feat: run the WGPU backend on macOS via MoltenVK, with graceful adapter errors

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,3 +5,13 @@ rustflags = ["-C", "target-cpu=native"]
 # Prevent pyo3 rebuilding all the time.
 [env]
 PYO3_PYTHON = "/usr/bin/python3"
+
+# macOS: let `cargo run`/`cargo test` find the Homebrew Vulkan loader
+# (libvulkan.dylib), which in turn loads MoltenVK. Apple GPUs have no native
+# Vulkan and sassy's rust-gpu kernel targets SPIR-V/Vulkan, so the wgpu backend
+# runs through MoltenVK there. This prepends the Homebrew lib dirs (Apple Silicon
+# and Intel) to the dyld search path without replacing the OS default fallbacks;
+# not force-set, so a developer's own value wins. Harmless on Linux/Windows
+# (DYLD_* is macOS-only). Applies to cargo run/test only -- for an installed or
+# directly-invoked binary, export the var yourself (see the README).
+DYLD_LIBRARY_PATH = { value = "/opt/homebrew/lib:/usr/local/lib", force = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ cust = { git = "https://github.com/rust-gpu/rust-cuda", rev = "103a8d56935c4e088
 kernels = { path = "kernels", optional = true }
 
 # Optional: WGPU GPU acceleration (cross-platform: Vulkan, Metal, DX12, OpenGL)
-wgpu = { version = "26.0", features = ["spirv"], optional = true }
+wgpu = { version = "26.0", features = ["spirv", "vulkan", "vulkan-portability"], optional = true }
 pollster = { version = "0.3", optional = true }
 futures = { version = "0.3", optional = true }
 bytemuck = { version = "1.25.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -347,3 +347,37 @@ int main() {
     sassy_searcher_free(searcher);
 }
 ```
+
+## Running the GPU (WGPU) backend on macOS
+
+The experimental GPU backend (`--features wgpu`) compiles the Myers kernel from
+Rust to SPIR-V via [rust-gpu](https://github.com/rust-gpu/rust-gpu), which only
+targets Vulkan. Apple GPUs have no native Vulkan, so on macOS the kernel runs
+through **MoltenVK** (a Vulkan-on-Metal translation layer). Native Metal is not
+an option for this kernel: wgpu's SPIR-V→Metal path (naga) rejects rust-gpu's
+output (`Uint scalar width 1 is not supported`).
+
+One-time setup:
+
+```sh
+brew install molten-vk vulkan-loader
+```
+
+`cargo run`/`cargo test` then find the loader automatically via `.cargo/config.toml`.
+For an installed or directly-invoked binary, export the path yourself:
+
+```sh
+export DYLD_LIBRARY_PATH="$(brew --prefix)/lib:$DYLD_LIBRARY_PATH"
+```
+
+Then, e.g.:
+
+```sh
+cargo run -F wgpu,cli --no-default-features --example modes -- -n 100000 -m 20 -k 3 -p 1000 -t 1
+```
+
+**Performance note:** on Apple integrated graphics via MoltenVK the GPU backend is
+a correctness/development vehicle, not a speed win at small scale. The optimized CPU
+SIMD path (`v2`) is competitive up to a few thousand patterns; the GPU pulls ahead
+only with large pattern batches. Expect the real performance story on a discrete
+NVIDIA/AMD GPU with native Vulkan.

--- a/src/pattern_tiling/general.rs
+++ b/src/pattern_tiling/general.rs
@@ -463,7 +463,7 @@ impl<P: Profile> Searcher<P> {
             .as_ref()
             .unwrap()
             .search_ranges::<P>(queries, text, k, Some(alpha))
-            .expect("WGPU search failed");
+            .unwrap_or_else(|e| panic!("WGPU search failed: {e}"));
 
         dispatch_encoded!(self, encoded_queries, |searcher, tq| {
             trace_ranges_backend(

--- a/src/pattern_tiling/search.rs
+++ b/src/pattern_tiling/search.rs
@@ -118,6 +118,14 @@ impl<B: SimdBackend, P: Profile> Myers<B, P> {
         }
 
         // eprintln!("length_mask: {} {}", self.active_ranges.len(), n_queries);
+        // The WGPU trace path reaches search_prep without going through
+        // `search_ranges` (range finding runs on the GPU), so the per-query
+        // `active_ranges` buffer may not yet be sized to `n_queries`. The CPU
+        // path always resizes it beforehand; do the same defensively here so
+        // the fill below cannot index out of bounds.
+        if self.active_ranges.len() < n_queries {
+            self.active_ranges.resize(n_queries, isize::MIN);
+        }
         self.active_ranges[..n_queries].fill(isize::MIN);
         self.hit_ranges.clear();
     }

--- a/src/pattern_tiling/search_wgpu.rs
+++ b/src/pattern_tiling/search_wgpu.rs
@@ -276,19 +276,8 @@ impl MyersWgpu {
 
         let peqs = precompute_peqs::<P>(queries);
 
-        let max_hits = (num_patterns as usize * 10).max(1);
-
-        let params = MyersParams {
-            text_len: text.len() as u32,
-            pattern_length,
-            num_patterns,
-            k,
-            alpha_pattern,
-            last_bit_shift: pattern_length.saturating_sub(1),
-            max_hits: max_hits as u32,
-        };
-
-        // Create buffers.
+        // Text and PEQ buffers are independent of max_hits, so build them once
+        // and reuse them across the grow-and-retry dispatches below.
         let text_buffer = self
             .device
             .create_buffer_init(&wgpu::util::BufferInitDescriptor {
@@ -305,7 +294,81 @@ impl MyersWgpu {
                 usage: wgpu::BufferUsages::STORAGE,
             });
 
-        let hit_ranges_size = (max_hits * std::mem::size_of::<GpuHitRange>()) as u64;
+        let num_workgroups = num_patterns.div_ceil(gpu_kernel::WORKGROUP_SIZE);
+
+        // The kernel counts every hit atomically but only writes ranges while
+        // idx < max_hits. If the true count exceeds the buffer, the surplus is
+        // dropped, so grow to the reported count and re-dispatch until every hit
+        // fits (converges in <= 2 iterations: the retry sizes to the exact count).
+        let mut max_hits = (num_patterns as usize * 10).max(1);
+        let (hit_count, hit_ranges_staging) = loop {
+            let params = MyersParams {
+                text_len: text.len() as u32,
+                pattern_length,
+                num_patterns,
+                k,
+                alpha_pattern,
+                last_bit_shift: pattern_length.saturating_sub(1),
+                max_hits: max_hits as u32,
+            };
+            let (hit_count, hit_ranges_staging) = self
+                .dispatch_and_count(&params, &text_buffer, &peqs_buffer, num_workgroups)
+                .await?;
+            match next_hit_capacity(hit_count, max_hits as u32) {
+                Some(bigger) => max_hits = bigger as usize, // overflow: grow and retry
+                None => break (hit_count, hit_ranges_staging),
+            }
+        };
+
+        let actual_hits = (hit_count as usize).min(max_hits);
+        if actual_hits == 0 {
+            return Ok(Vec::new());
+        }
+
+        // Read back hit ranges.
+        let ranges_slice = hit_ranges_staging.slice(..);
+        let (ranges_sender, ranges_receiver) = futures::channel::oneshot::channel();
+        ranges_slice.map_async(wgpu::MapMode::Read, move |result| {
+            let _ = ranges_sender.send(result);
+        });
+        let _ = self.device.poll(wgpu::PollType::Wait);
+        ranges_receiver
+            .await
+            .map_err(|e| WgpuSearchError::Other(format!("Channel error: {e:?}")))?
+            .map_err(|e| WgpuSearchError::Other(format!("Buffer async error: {e:?}")))?;
+
+        let hit_ranges = {
+            let view = ranges_slice.get_mapped_range();
+            let gpu_ranges: &[GpuHitRange] = bytemuck::cast_slice(&view);
+            gpu_ranges[..actual_hits]
+                .iter()
+                .map(|r| HitRange {
+                    pattern_idx: r.pattern_idx as usize,
+                    start: r.start as isize,
+                    end: r.end as isize,
+                })
+                .collect()
+        };
+        hit_ranges_staging.unmap();
+
+        Ok(hit_ranges)
+    }
+
+    /// Dispatch the kernel once with `params` and read back the atomic hit count.
+    /// Returns the count and the hit-ranges staging buffer (mapped-readable), so
+    /// the caller can read ranges from the final, non-overflowing dispatch. Fresh
+    /// hit-ranges/hit-count buffers are created each call (their size depends on
+    /// `params.max_hits`); the `text`/`peqs` buffers are passed in and reused.
+    async fn dispatch_and_count(
+        &self,
+        params: &MyersParams,
+        text_buffer: &wgpu::Buffer,
+        peqs_buffer: &wgpu::Buffer,
+        num_workgroups: u32,
+    ) -> Result<(u32, wgpu::Buffer), WgpuSearchError> {
+        let hit_ranges_size =
+            (params.max_hits as usize * std::mem::size_of::<GpuHitRange>()) as u64;
+
         let hit_ranges_buffer = self.device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("Myers Hit Ranges Buffer"),
             size: hit_ranges_size,
@@ -358,8 +421,6 @@ impl MyersWgpu {
             ],
         });
 
-        let num_workgroups = num_patterns.div_ceil(gpu_kernel::WORKGROUP_SIZE);
-
         let mut encoder = self
             .device
             .create_command_encoder(&wgpu::CommandEncoderDescriptor {
@@ -373,17 +434,11 @@ impl MyersWgpu {
             });
             compute_pass.set_pipeline(&self.pipeline);
             compute_pass.set_bind_group(0, &bind_group, &[]);
-            compute_pass.set_push_constants(0, bytemuck::bytes_of(&params));
+            compute_pass.set_push_constants(0, bytemuck::bytes_of(params));
             compute_pass.dispatch_workgroups(num_workgroups.max(1), 1, 1);
         }
 
-        encoder.copy_buffer_to_buffer(
-            &hit_ranges_buffer,
-            0,
-            &hit_ranges_staging,
-            0,
-            hit_ranges_size,
-        );
+        encoder.copy_buffer_to_buffer(&hit_ranges_buffer, 0, &hit_ranges_staging, 0, hit_ranges_size);
         encoder.copy_buffer_to_buffer(
             &hit_count_buffer,
             0,
@@ -409,43 +464,24 @@ impl MyersWgpu {
 
         let hit_count = {
             let view = count_slice.get_mapped_range();
-            let count: u32 = bytemuck::cast_slice::<u8, u32>(&view)[0];
-            count
+            bytemuck::cast_slice::<u8, u32>(&view)[0]
         };
         hit_count_staging.unmap();
 
-        let actual_hits = (hit_count as usize).min(max_hits);
-        if actual_hits == 0 {
-            return Ok(Vec::new());
-        }
+        Ok((hit_count, hit_ranges_staging))
+    }
+}
 
-        // Read back hit ranges.
-        let ranges_slice = hit_ranges_staging.slice(..);
-        let (ranges_sender, ranges_receiver) = futures::channel::oneshot::channel();
-        ranges_slice.map_async(wgpu::MapMode::Read, move |result| {
-            let _ = ranges_sender.send(result);
-        });
-        let _ = self.device.poll(wgpu::PollType::Wait);
-        ranges_receiver
-            .await
-            .map_err(|e| WgpuSearchError::Other(format!("Channel error: {e:?}")))?
-            .map_err(|e| WgpuSearchError::Other(format!("Buffer async error: {e:?}")))?;
-
-        let hit_ranges = {
-            let view = ranges_slice.get_mapped_range();
-            let gpu_ranges: &[GpuHitRange] = bytemuck::cast_slice(&view);
-            gpu_ranges[..actual_hits]
-                .iter()
-                .map(|r| HitRange {
-                    pattern_idx: r.pattern_idx as usize,
-                    start: r.start as isize,
-                    end: r.end as isize,
-                })
-                .collect()
-        };
-        hit_ranges_staging.unmap();
-
-        Ok(hit_ranges)
+/// Given the atomically-counted hit total reported by the kernel and the
+/// capacity of the output buffer it wrote into, return `Some(new_capacity)` if
+/// the buffer overflowed (so the caller must re-dispatch with a bigger buffer),
+/// or `None` if all hits fit. The kernel counts every hit but only writes while
+/// `idx < max_hits`, so `reported > capacity` means hits were dropped.
+fn next_hit_capacity(reported: u32, current_capacity: u32) -> Option<u32> {
+    if reported > current_capacity {
+        Some(reported)
+    } else {
+        None
     }
 }
 
@@ -505,6 +541,18 @@ fn generate_alpha_mask(alpha: f32, length: usize) -> u64 {
     }
 
     mask
+}
+
+#[cfg(test)]
+mod max_hits_tests {
+    use super::next_hit_capacity;
+
+    #[test]
+    fn detects_overflow_and_requests_true_count() {
+        assert_eq!(next_hit_capacity(5, 10), None); // fits: no retry
+        assert_eq!(next_hit_capacity(10, 10), None); // exactly full: no drop
+        assert_eq!(next_hit_capacity(23, 10), Some(23)); // overflow: grow to 23
+    }
 }
 
 #[cfg(test)]

--- a/src/pattern_tiling/search_wgpu.rs
+++ b/src/pattern_tiling/search_wgpu.rs
@@ -515,7 +515,7 @@ mod tests {
     #[test]
     #[ignore] // Only run when a WGPU-compatible GPU/driver is available.
     fn test_wgpu_search_basic() {
-        let searcher = pollster::block_on(MyersWgpu::new()).expect("Failed to initialize WGPU");
+        let searcher = MyersWgpu::new();
 
         let queries = vec![b"ACGT".to_vec(), b"TGCA".to_vec()];
         let text = b"AAACGTTTGCAAA";

--- a/src/pattern_tiling/search_wgpu.rs
+++ b/src/pattern_tiling/search_wgpu.rs
@@ -56,13 +56,22 @@ pub struct MyersWgpu {
 
 impl MyersWgpu {
     pub fn new() -> Self {
-        pollster::block_on(Self::new_async()).unwrap()
+        Self::new_checked().unwrap_or_else(|e| panic!("{e}\n\n{}", adapter_help_message()))
+    }
+
+    /// Fallible constructor. Returns `WgpuSearchError::NoAdapter` when no Vulkan
+    /// adapter is available; see [`adapter_help_message`] for platform guidance.
+    pub fn new_checked() -> Result<Self, WgpuSearchError> {
+        pollster::block_on(Self::new_async())
     }
     /// Initialize the WGPU device and compute pipeline. We require the Vulkan
     /// backend (matching the `spirv-unknown-vulkan1.2` target used to compile
-    /// the kernel): other backends (GL, DX12 without passthrough) go through
-    /// naga's SPIR-V -> IR translation, which does not support all the
-    /// constructs emitted by rustc_codegen_spirv (e.g. narrow/bool types).
+    /// the kernel) with raw SPIR-V passthrough. The native Metal backend goes
+    /// through naga's SPIR-V -> IR translation, which rejects rust-gpu's output:
+    /// `Uint scalar width 1 is not supported` (that width-1 uint is intrinsic --
+    /// it comes from ordinary comparisons -- alongside u64/atomic and
+    /// `Block`-decoration gaps). On macOS this runs via MoltenVK (SPIRV-Cross),
+    /// which legalizes those constructs.
     pub async fn new_async() -> Result<Self, WgpuSearchError> {
         let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
             backends: wgpu::Backends::VULKAN,
@@ -135,9 +144,9 @@ impl MyersWgpu {
 
     fn create_pipeline(device: &wgpu::Device) -> (wgpu::ComputePipeline, wgpu::BindGroupLayout) {
         // Prefer raw SPIR-V passthrough (bypasses naga's SPIR-V -> IR
-        // translation, which does not support all constructs emitted by
-        // rustc_codegen_spirv, e.g. narrow/bool types). Fall back to the
-        // naga-validated path if the device doesn't support passthrough.
+        // translation, which rejects rust-gpu's output -- e.g. `Uint scalar
+        // width 1 is not supported`). Fall back to the naga-validated path if
+        // the device doesn't support passthrough.
         let shader_module = if device
             .features()
             .contains(wgpu::Features::SPIRV_SHADER_PASSTHROUGH)
@@ -472,6 +481,20 @@ impl MyersWgpu {
     }
 }
 
+/// Actionable guidance shown when no Vulkan adapter is found. On macOS the fix is
+/// MoltenVK (Apple GPUs have no native Vulkan; sassy's rust-gpu kernel targets
+/// SPIR-V/Vulkan). Elsewhere it is a missing or broken Vulkan driver/loader.
+pub(crate) fn adapter_help_message() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "No Vulkan adapter found. On macOS, sassy's GPU kernel runs through MoltenVK; \
+         install it and the Vulkan loader with:\n  brew install molten-vk vulkan-loader\n\
+         (Apple GPUs have no native Vulkan support.)"
+    } else {
+        "No Vulkan adapter found. Ensure a Vulkan driver and loader are installed \
+         and visible to this process."
+    }
+}
+
 /// Given the atomically-counted hit total reported by the kernel and the
 /// capacity of the output buffer it wrote into, return `Some(new_capacity)` if
 /// the buffer overflowed (so the caller must re-dispatch with a bigger buffer),
@@ -552,6 +575,21 @@ mod max_hits_tests {
         assert_eq!(next_hit_capacity(5, 10), None); // fits: no retry
         assert_eq!(next_hit_capacity(10, 10), None); // exactly full: no drop
         assert_eq!(next_hit_capacity(23, 10), Some(23)); // overflow: grow to 23
+    }
+}
+
+#[cfg(test)]
+mod adapter_help_tests {
+    use super::adapter_help_message;
+
+    #[test]
+    fn message_is_platform_appropriate() {
+        let msg = adapter_help_message();
+        assert!(msg.contains("Vulkan"));
+        #[cfg(target_os = "macos")]
+        assert!(msg.contains("brew install molten-vk"));
+        #[cfg(not(target_os = "macos"))]
+        assert!(!msg.contains("brew"));
     }
 }
 

--- a/src/pattern_tiling/trace.rs
+++ b/src/pattern_tiling/trace.rs
@@ -287,9 +287,14 @@ pub fn trace_batch_ranges<B: SimdBackend, P: Profile>(
 
     // Prep allocs for single block search
     let length_mask = (!0u64) >> (64usize.saturating_sub(t_queries.pattern_length));
+    // Only the current trace batch (<= LANES) is active here, so size the
+    // per-query state to `filled_till`, consistent with `history`/`positions`
+    // (sized by `ensure_capacity(1, buffer.filled_till)` above). The GPU search
+    // path reaches this without `Myers::search_ranges` having grown the buffers
+    // to `n_queries`, so passing `n_queries` here would overrun `active_ranges`.
     searcher.search_prep(
         1,
-        t_queries.n_queries,
+        buffer.filled_till,
         t_queries.pattern_length,
         searcher.alpha_pattern & length_mask,
     );
@@ -449,4 +454,34 @@ fn traceback_single<B: SimdBackend, P: Profile>(
     };
 
     m
+}
+
+#[cfg(test)]
+mod trace_gpu_path_tests {
+    use super::*;
+    use crate::pattern_tiling::backend::U32Backend;
+    use crate::pattern_tiling::search::{HitRange, Myers};
+    use crate::pattern_tiling::tqueries::TQueries;
+    use crate::profiles::Iupac;
+
+    // Reproduces the GPU trace path: a fresh Myers (per-query buffers never grown
+    // by search_ranges) traced against RC-doubled queries whose n_queries far
+    // exceeds a single block. Must not panic / index out of bounds.
+    #[test]
+    fn trace_batch_ranges_tolerates_ungrown_active_ranges() {
+        let mut searcher = Myers::<U32Backend, Iupac>::new(None);
+        let queries = vec![b"ACGTACGTACGTACGTACGT".to_vec()]; // 1 pattern, 20bp
+        let tq = TQueries::<U32Backend, Iupac>::new(&queries, /*include_rc=*/ true);
+        assert!(tq.n_queries >= 2, "RC should give n_queries >= 2");
+
+        let text = b"ACGTACGTACGTACGTACGTACGT";
+        let ranges = [HitRange { pattern_idx: 0, start: 0, end: 19 }];
+        let mut buffer = TraceBuffer::new(U32Backend::LANES);
+
+        // Pre-fix: panics "range end index {n_queries} out of range for slice of length {LANES-ish}".
+        trace_batch_ranges::<U32Backend, Iupac>(
+            &mut searcher, &tq, text, &ranges, 3,
+            TracePostProcess::LocalMinima, None, None, &mut buffer,
+        );
+    }
 }


### PR DESCRIPTION
Makes the WGPU backend build and run on macOS (Apple Silicon), for local development and validation before renting cloud GPUs.

> **Stacked on #73.** This branch is built on top of the correctness fixes in #73. Until #73 merges, GitHub shows its three commits here too; the macOS-specific commits in this PR are the last three: `feat: actionable, platform-aware error…`, `build: discover the Homebrew Vulkan loader…`, and `docs: how to run the WGPU backend on macOS…`. Best reviewed/merged after #73.

## Why MoltenVK, not native Metal

The kernel is compiled Rust → SPIR-V (rust-gpu), which only targets Vulkan. Apple GPUs have no native Vulkan, so on macOS the kernel runs through MoltenVK (a Vulkan-on-Metal translation layer). Native Metal is not viable: wgpu's SPIR-V → Metal path (naga) rejects rust-gpu's output — `Uint scalar width 1 is not supported`, and that width-1 uint is intrinsic (it comes from ordinary comparisons, so it can't be removed from the source). MoltenVK's SPIRV-Cross legalizes it. The misleading "narrow/bool types" code comments are corrected with this concrete finding.

## Changes

- Enable wgpu `vulkan` + `vulkan-portability` features. The Vulkan backend is not a macOS default, and portability enumeration is what surfaces MoltenVK's portability device. Both are additive and harmless on Linux/Windows.
- Add a `.cargo/config.toml [env]` line so `cargo run` / `cargo test` locate the Homebrew Vulkan loader (`libvulkan.dylib`) with no manual setup. It prepends the Homebrew lib dirs to `DYLD_LIBRARY_PATH` without replacing the OS default fallbacks, is not force-set (a developer's own value wins), and is macOS-only (DYLD_* is ignored elsewhere).
- Replace the raw `unwrap`/`expect` on GPU init with a platform-aware, actionable error: on macOS it points to `brew install molten-vk vulkan-loader`; elsewhere it gives generic Vulkan driver/loader guidance. Adds `MyersWgpu::new_checked()` returning `Result`.
- README "Running on macOS" section, including the CPU↔GPU crossover performance note (on Apple integrated graphics via MoltenVK the GPU backend is a correctness/dev vehicle, not a small-scale speed win).

## Setup on macOS

```sh
brew install molten-vk vulkan-loader
cargo run -F wgpu,cli --no-default-features --example modes -- -n 100000 -m 20 -k 3 -p 1000 -t 1
```
