### PR TITLE
perf: text-direction tiling + parallel PEQ on top of the u32 kernel

### DIFF
--- a/gpu_kernel/src/lib.rs
+++ b/gpu_kernel/src/lib.rs
@@ -43,6 +43,10 @@ pub struct MyersParams {
     pub alpha_pattern: T,
     pub last_bit_shift: u32,
     pub max_hits: u32,
+    /// Text positions each tile owns; `0` = one tile over the whole text.
+    pub tile_size: u32,
+    /// ceil(text_len / tile_size), precomputed on the host; `1` when not tiling.
+    pub n_tiles: u32,
 }
 
 /// Type alias for pattern equality vectors
@@ -114,21 +118,58 @@ pub fn myers_search_kernel(
     #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] hit_count: &mut [u32],
     #[spirv(push_constant)] params: &MyersParams,
 ) {
-    let thread_id = global_id.x as usize;
+    use spirv_std::arch::atomic_i_add;
+    use spirv_std::memory::{Scope, Semantics};
 
-    // Early exit if thread ID exceeds number of patterns
-    if thread_id >= params.num_patterns as usize {
+    let thread_id = global_id.x as usize;
+    let text_len = params.text_len as usize;
+
+    // One thread per (pattern, tile); n_tiles <= 1 is one tile over the whole text.
+    let n_tiles = if params.n_tiles == 0 { 1usize } else { params.n_tiles as usize };
+    if thread_id >= params.num_patterns as usize * n_tiles {
         return;
     }
+    let pattern_id = thread_id / n_tiles;
+    let tile_id = thread_id % n_tiles;
 
-    // Each thread processes one pattern
-    let pattern_peqs_offset = thread_id * 256;
+    let tile_size = if params.tile_size == 0 {
+        text_len
+    } else {
+        params.tile_size as usize
+    };
+
+    // This tile emits only runs whose start is in [owned_start, owned_end), so
+    // every run is emitted by exactly one tile.
+    let owned_start = tile_id * tile_size;
+    let owned_end_unclamped = owned_start + tile_size;
+    let owned_end = if owned_end_unclamped < text_len {
+        owned_end_unclamped
+    } else {
+        text_len
+    };
+    if owned_start >= text_len {
+        return; // tile entirely past the text (rounding slack)
+    }
+
+    // A match spans <= m + k chars, so starting m + k before owned_start makes the
+    // Myers state correct from there on. (No saturating_sub on SPIR-V.)
+    let pattern_length = params.pattern_length as usize;
+    let margin = pattern_length + params.k as usize;
+    let scan_start = if owned_start > margin {
+        owned_start - margin
+    } else {
+        0
+    };
+    let scan_end_unclamped = owned_end + margin;
+    let scan_end = if scan_end_unclamped < text_len {
+        scan_end_unclamped
+    } else {
+        text_len
+    };
+
+    let pattern_peqs_offset = pattern_id * 256;
     let last_bit_mask = (1 as T) << params.last_bit_shift;
 
-    // Initialize Myers state
-    // `saturating_sub` is not supported on the SPIR-V target, so compute the
-    // shift amount with a branchless equivalent.
-    let pattern_length = params.pattern_length as usize;
     let shift_amount = if pattern_length >= 64 {
         0
     } else {
@@ -142,20 +183,17 @@ pub fn myers_search_kernel(
 
     let all_ones: T = !0;
 
-    // Track active range
     let mut is_active = false;
+    let mut emitting = false; // inside a run this tile owns
     let mut range_start = -1i32;
 
-    // Process each position in text
-    let text_len = params.text_len as usize;
-    for pos in 0..text_len {
-        // Read character
+    // Scan the tile plus margin, but keep going past scan_end while a run this tile
+    // owns is still open (a low-cost stretch longer than the margin). Indices are in
+    // bounds by construction, so the reads are unchecked.
+    let mut pos = scan_start;
+    while pos < text_len && (pos < scan_end || emitting) {
         let c = unsafe { *text.get_unchecked(pos) };
-
-        // Look up pre-computed equality vector for this char
         let eq = unsafe { *peqs.get_unchecked(pattern_peqs_offset + c as usize) };
-
-        // Execute Myers step
         let (vp_new, vn_new, cost_new) = myers_step_scalar(
             vp,
             vn,
@@ -165,26 +203,23 @@ pub fn myers_search_kernel(
             params.last_bit_shift,
             last_bit_mask,
         );
-
         vp = vp_new;
         vn = vn_new;
         cost = cost_new;
 
-        // Check if cost is within threshold
         let was_active = is_active;
         is_active = cost <= params.k as T;
 
-        // Handle range transitions
         if is_active && !was_active {
-            // Range starting
-            range_start = pos as i32;
+            // A run starts at `pos`; own it iff pos is in [owned_start, owned_end).
+            if pos >= owned_start && pos < owned_end {
+                emitting = true;
+                range_start = pos as i32;
+            } else {
+                emitting = false;
+            }
         } else if !is_active && was_active {
-            // Range ending - emit hit
-            // Use atomic to get unique slot
-            #[cfg(target_arch = "spirv")]
-            {
-                use spirv_std::arch::atomic_i_add;
-                use spirv_std::memory::{Scope, Semantics};
+            if emitting {
                 let idx = unsafe {
                     atomic_i_add::<
                         u32,
@@ -192,41 +227,35 @@ pub fn myers_search_kernel(
                         { Semantics::UNIFORM_MEMORY.bits() },
                     >(&mut hit_count[0], 1)
                 };
-
                 if idx < params.max_hits {
                     hit_ranges[idx as usize] = HitRange {
-                        pattern_idx: thread_id as u32,
+                        pattern_idx: pattern_id as u32,
                         start: range_start,
                         end: (pos - 1) as i32,
                         _padding: 0,
                     };
                 }
+                emitting = false;
             }
         }
+        pos += 1;
     }
 
-    // Finalize: if still active at end, emit final range
-    if is_active {
-        #[cfg(target_arch = "spirv")]
-        {
-            use spirv_std::arch::atomic_i_add;
-            use spirv_std::memory::{Scope, Semantics};
-            let idx = unsafe {
-                atomic_i_add::<
-                    u32,
-                    { Scope::QueueFamily as u32 },
-                    { Semantics::UNIFORM_MEMORY.bits() },
-                >(&mut hit_count[0], 1)
+    // Finalize: a run this tile owns that is still active at the end of the scan.
+    if emitting {
+        let idx = unsafe {
+            atomic_i_add::<u32, { Scope::QueueFamily as u32 }, { Semantics::UNIFORM_MEMORY.bits() }>(
+                &mut hit_count[0],
+                1,
+            )
+        };
+        if idx < params.max_hits {
+            hit_ranges[idx as usize] = HitRange {
+                pattern_idx: pattern_id as u32,
+                start: range_start,
+                end: (pos - 1) as i32,
+                _padding: 0,
             };
-
-            if idx < params.max_hits {
-                hit_ranges[idx as usize] = HitRange {
-                    pattern_idx: thread_id as u32,
-                    start: range_start,
-                    end: (text_len - 1) as i32,
-                    _padding: 0,
-                };
-            }
         }
     }
 }

--- a/src/pattern_tiling/search_wgpu.rs
+++ b/src/pattern_tiling/search_wgpu.rs
@@ -113,12 +113,18 @@ impl MyersWgpu {
                 wgpu::Features::PUSH_CONSTANTS
             };
 
+        // The PEQ table is one storage buffer, so at high pattern counts it exceeds
+        // the default 128 MiB binding cap. Request the adapter's actual maxima.
+        let adapter_limits = adapter.limits();
         let (device, queue) = adapter
             .request_device(&wgpu::DeviceDescriptor {
                 label: Some("Myers WGPU Device"),
                 required_features,
                 required_limits: wgpu::Limits {
                     max_push_constant_size: 128,
+                    max_storage_buffer_binding_size: adapter_limits
+                        .max_storage_buffer_binding_size,
+                    max_buffer_size: adapter_limits.max_buffer_size,
                     ..Default::default()
                 },
                 memory_hints: Default::default(),

--- a/src/pattern_tiling/search_wgpu.rs
+++ b/src/pattern_tiling/search_wgpu.rs
@@ -539,28 +539,31 @@ fn precompute_peqs<P: Profile>(queries: &[Vec<u8>]) -> Vec<T> {
         *slot = P::encode_char(v as u8);
     }
 
-    for (pattern_idx, query) in queries.iter().enumerate() {
-        let base_offset = pattern_idx * 256;
-        for (pos, &pattern_byte) in query.iter().enumerate() {
-            if pos >= 64 {
-                break; // Limit to 64-bit patterns.
-            }
-            let enc_pattern = P::encode_char(pattern_byte);
-            if enc_pattern == 0 {
-                continue; // Skip wildcard/unmatched pattern chars, as in TQueries::new.
-            }
-            let bit = 1 << pos;
-            // A pattern position matches a text byte whenever their IUPAC
-            // encodings share at least one bit (ambiguity-code compatible),
-            // mirroring the bitwise-overlap check in `TQueries::new` /
-            // `Profile::is_match`.
-            for (byte, &enc_text) in encoded_byte.iter().enumerate() {
-                if (enc_pattern & enc_text) != 0 {
-                    peqs[base_offset + byte] |= bit;
+    // Each pattern owns a disjoint 256-entry slice, so this parallelizes cleanly.
+    use rayon::prelude::*;
+    peqs.par_chunks_mut(256)
+        .zip(queries.par_iter())
+        .for_each(|(chunk, query)| {
+            for (pos, &pattern_byte) in query.iter().enumerate() {
+                if pos >= 64 {
+                    break; // Limit to 64-bit patterns.
+                }
+                let enc_pattern = P::encode_char(pattern_byte);
+                if enc_pattern == 0 {
+                    continue; // Skip wildcard/unmatched pattern chars, as in TQueries::new.
+                }
+                let bit = 1 << pos;
+                // A pattern position matches a text byte whenever their IUPAC
+                // encodings share at least one bit (ambiguity-code compatible),
+                // mirroring the bitwise-overlap check in `TQueries::new` /
+                // `Profile::is_match`.
+                for (byte, &enc_text) in encoded_byte.iter().enumerate() {
+                    if (enc_pattern & enc_text) != 0 {
+                        chunk[byte] |= bit;
+                    }
                 }
             }
-        }
-    }
+        });
 
     peqs
 }

--- a/src/pattern_tiling/search_wgpu.rs
+++ b/src/pattern_tiling/search_wgpu.rs
@@ -311,7 +311,18 @@ impl MyersWgpu {
                 usage: wgpu::BufferUsages::STORAGE,
             });
 
-        let num_workgroups = num_patterns.div_ceil(gpu_kernel::WORKGROUP_SIZE);
+        // Tile the text into ~TARGET_THREADS threads total to fill the GPU at low
+        // pattern counts; collapses to one tile once patterns alone suffice.
+        const TARGET_THREADS: u32 = 1 << 16; // 65536
+        const MIN_TILE: u32 = 2048; // bound the per-tile m+k recompute overhead
+        let text_len_u32 = text.len() as u32;
+        let n_tiles = {
+            let want = (TARGET_THREADS / num_patterns.max(1)).max(1);
+            let max_useful = (text_len_u32 / MIN_TILE).max(1);
+            want.min(max_useful)
+        };
+        let tile_size = text_len_u32.div_ceil(n_tiles);
+        let num_workgroups = (num_patterns * n_tiles).div_ceil(gpu_kernel::WORKGROUP_SIZE);
 
         // The kernel counts every hit atomically but only writes ranges while
         // idx < max_hits. If the true count exceeds the buffer, the surplus is
@@ -327,6 +338,8 @@ impl MyersWgpu {
                 alpha_pattern,
                 last_bit_shift: pattern_length.saturating_sub(1),
                 max_hits: max_hits as u32,
+                tile_size,
+                n_tiles,
             };
             let (hit_count, hit_ranges_staging) = self
                 .dispatch_and_count(&params, &text_buffer, &peqs_buffer, num_workgroups)


### PR DESCRIPTION
Rebased onto your u32 kernel, so this is just what tiling adds on top of the 32-bit change.

The kernel ran one thread per pattern, each scanning the whole text, so at low pattern counts the GPU sat mostly idle and lost to the CPU. This splits the text into tiles and runs one thread per (pattern, tile); each tile scans an extra `m+k` margin so the Myers state is correct at the boundary, and only emits a match whose start falls in its own region (so each match is emitted once). It's adaptive — aim for ~65k threads, collapse back to one tile once there are enough patterns to fill the GPU on their own. The second commit just parallelizes the PEQ precompute over rayon.

T4, native Vulkan, `-n 100000 -m 20 -k 3 -t 1`, warm, GPU count matches v2 everywhere. Times in ms:

| -p | u32 (your gpu) | u32 + tiling | v2 (CPU) |
|----|----|----|----|
| 100 | 18 | 3.0 | 3.3 |
| 500 | 37 | 5.0 | 11 |
| 1000 | 40 | 7.4 | 21 |
| 5000 | 65 | 30 | 118 |
| 10000 | 99 | 56 | 232 |

So p=1000 goes 40 → 7.4 ms, and the GPU beats the CPU from ~p=500 instead of only above ~p=5000. On a longer text (n=1M, p=20000) it's 894 → 538 ms vs 4.4 s on the CPU.

Two caveats: above ~p=50000 tiling is off (enough patterns already), and there the GPU is actually a bit behind the CPU. I also folded in the storage-buffer-limit fix from the correctness set that didn't make it into what you merged — it's what lets the PEQ buffer bind past 128 MiB at very high p.

Also checked on my Mac via MoltenVK, and the lib tests pass.
